### PR TITLE
Channel

### DIFF
--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -430,7 +430,9 @@ func createNoBlockPStore() *pstore.NoBlockPStore {
 		*fPStoreBatchSize,
 		*fPStoreChannelCapacity,
 		time.Second)
-	result.RegisterMetrics()
+	if err := result.RegisterMetrics(); err != nil {
+		panic(err)
+	}
 	return result
 }
 
@@ -493,7 +495,9 @@ func initHostsPortsAndStore(
 		(*fBytesPerPage)/24, computePageCount(), firstEndpoints)
 	fmt.Println("Initialization complete.")
 	firstStore, _ := result.Get()
-	firstStore.RegisterMetrics()
+	if err := firstStore.RegisterMetrics(); err != nil {
+		panic(err)
+	}
 	// Endpoint refresher goroutine
 	go func() {
 		for {

--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -34,10 +34,6 @@ import (
 	"time"
 )
 
-const (
-	totalNumberOfEndpoints = 10000
-)
-
 var (
 	fBytesPerPage = flag.Int(
 		"bytes_per_page",
@@ -47,10 +43,6 @@ var (
 		"page_count",
 		30*1000*1000,
 		"Buffer size per endpoint in records")
-	fHostFile = flag.String(
-		"host_file",
-		"",
-		"File containing all the nodes")
 	fAppFile = flag.String(
 		"app_file",
 		"apps.yaml",
@@ -71,125 +63,19 @@ var (
 		"collection_frequency",
 		30*time.Second,
 		"Amount of time between metric collections")
-	fPStoreUpdateFrequency = flag.Duration(
-		"pstore_update_frequency",
-		30*time.Second,
-		"Amount of time between writing newest metrics to persistent storage")
 	fPStoreBatchSize = flag.Int(
 		"pstore_batch_size",
 		1000,
-		"Batch to write at least this many records to persistent storage")
+		"Write at most this many records at once to persistent storage")
+	fPStoreChannelCapacity = flag.Int(
+		"pstore_channel_capacity",
+		100000,
+		"The peristent storage buffer size in metric values")
 	fKafkaConfigFile = flag.String(
 		"kafka_config_file",
 		"",
 		"kafka configuration file")
 )
-
-var (
-	gHostsPortsAndStore            datastructs.HostsPortsAndStore
-	gCollectionTimesDist           = tricorder.NewGeometricBucketer(1e-4, 100.0).NewCumulativeDistribution()
-	gChangedMetricsPerEndpointDist = tricorder.NewGeometricBucketer(1.0, 10000.0).NewCumulativeDistribution()
-	gStatusCounts                  = newStatusCountType()
-	gConnectionErrors              = newConnectionErrorsType()
-	gApplicationStats              = datastructs.NewApplicationStatuses()
-	gApplicationList               *datastructs.ApplicationList
-	gNoBlockPStore                 *pstore.NoBlockPStore
-)
-
-type statusCountSnapshotType struct {
-	WaitingToConnectCount int
-	ConnectingCount       int
-	WaitingToPollCount    int
-	PollingCount          int
-	SyncedCount           int
-	FailedToConnectCount  int
-	FailedToPollCount     int
-}
-
-type statusCountType struct {
-	lock   sync.Mutex
-	counts map[collector.Status]int
-}
-
-func newStatusCountType() *statusCountType {
-	return &statusCountType{
-		counts: make(map[collector.Status]int),
-	}
-}
-
-func (s *statusCountType) Update(oldStatus, newStatus collector.Status) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	if oldStatus != collector.Unknown {
-		s.counts[oldStatus]--
-	}
-	if newStatus != collector.Unknown {
-		s.counts[newStatus]++
-	}
-}
-
-func (s *statusCountType) Snapshot(data *statusCountSnapshotType) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	data.WaitingToConnectCount =
-		s.counts[collector.WaitingToConnect]
-	data.ConnectingCount = s.counts[collector.Connecting]
-	data.WaitingToPollCount = s.counts[collector.WaitingToPoll]
-	data.PollingCount = s.counts[collector.Polling]
-	data.SyncedCount = s.counts[collector.Synced]
-	data.FailedToConnectCount =
-		s.counts[collector.FailedToConnect]
-	data.FailedToPollCount = s.counts[collector.FailedToPoll]
-}
-
-func (s *statusCountType) RegisterMetrics() {
-	var data statusCountSnapshotType
-	region := tricorder.RegisterRegion(func() {
-		s.Snapshot(&data)
-	})
-	tricorder.RegisterMetricInRegion(
-		"collector/waitingToConnect",
-		&data.WaitingToConnectCount,
-		region,
-		units.None,
-		"Number of goroutines waiting to connect")
-	tricorder.RegisterMetricInRegion(
-		"collector/connecting",
-		&data.ConnectingCount,
-		region,
-		units.None,
-		"Number of goroutines connecting")
-	tricorder.RegisterMetricInRegion(
-		"collector/waitingToPoll",
-		&data.WaitingToPollCount,
-		region,
-		units.None,
-		"Number of goroutines waiting to poll")
-	tricorder.RegisterMetricInRegion(
-		"collector/polling",
-		&data.PollingCount,
-		region,
-		units.None,
-		"Number of goroutines polling")
-	tricorder.RegisterMetricInRegion(
-		"collector/synced",
-		&data.SyncedCount,
-		region,
-		units.None,
-		"Number of endpoints synced")
-	tricorder.RegisterMetricInRegion(
-		"collector/connectFailures",
-		&data.FailedToConnectCount,
-		region,
-		units.None,
-		"Number of connection failures")
-	tricorder.RegisterMetricInRegion(
-		"collector/pollFailures",
-		&data.FailedToPollCount,
-		region,
-		units.None,
-		"Number of poll failures")
-}
 
 type byHostName messages.ErrorList
 
@@ -247,283 +133,32 @@ func (e *connectionErrorsType) GetErrors() (result messages.ErrorList) {
 	return
 }
 
-var (
-	aWriteError = errors.New("A bad write error.")
-)
-
-func endpointNameAndPort(
-	endpointNames []string,
-	endpointPorts []int,
-	i int) (name string, port int) {
-	length := len(endpointNames)
-	return fmt.Sprintf(
-			"%s*%d",
-			endpointNames[i%length],
-			i),
-		endpointPorts[i%length]
-}
-
-// metrics for pstoreHandlerType instances
-type pstoreHandlerData struct {
-	MetricsWritten   int64
-	WriteAttempts    int64
-	SuccessfulWrites int64
-	LastWriteError   string
-	EndpointsVisited int64
-}
-
-// pstoreHandlerType implements store.Visitor.
-// Its Visit method writes the latest value for each metric in the store to
-// persistent storage. It stores the last value for each endpoint and
-// metric it wrote to persistent storage so
-// that it can avoid writing the same value twice.
-// an pstoreHandlerType instance buffers writes so that each write to
-// persistent storage includes at least fPStoreBatchSize metrics.
-// pstoreHandlerType is NOT threadsafe.
-type pstoreHandlerType struct {
-	writer                  pstore.Writer
-	lastValues              map[*collector.Endpoint]map[*store.MetricInfo]interface{}
-	lastValuesThisEndpoint  map[*store.MetricInfo]interface{}
-	toBeWritten             []pstore.Record
-	timeSpentWritingDist    *tricorder.CumulativeDistribution
-	timeSpentCollectingDist *tricorder.CumulativeDistribution
-	totalTimeSpentDist      *tricorder.CumulativeDistribution
-	perBatchWriteDist       *tricorder.CumulativeDistribution
-	ttWriter                *timeTakenWriter
-	startTime               time.Time
-	// Protects all fields below
-	lock  sync.Mutex
-	stats pstoreHandlerData
-}
-
-func newPStoreHandler(w pstore.Writer) *pstoreHandlerType {
-	bucketer := tricorder.NewGeometricBucketer(1e-4, 1000.0)
-	return &pstoreHandlerType{
-		writer:                  w,
-		lastValues:              make(map[*collector.Endpoint]map[*store.MetricInfo]interface{}),
-		timeSpentWritingDist:    bucketer.NewCumulativeDistribution(),
-		timeSpentCollectingDist: bucketer.NewCumulativeDistribution(),
-		totalTimeSpentDist:      bucketer.NewCumulativeDistribution(),
-		perBatchWriteDist:       bucketer.NewCumulativeDistribution(),
-	}
-}
-
-func appName(port int) string {
-	return gApplicationList.ByPort(port).Name()
-}
-
-// Do not call this directly!
-func (p *pstoreHandlerType) Append(r *store.Record) {
-	kind := r.Info.Kind()
-	if !p.ttWriter.IsTypeSupported(kind) {
-		return
-	}
-	if p.lastValuesThisEndpoint[r.Info] == r.Value {
-		return
-	}
-	p.lastValuesThisEndpoint[r.Info] = r.Value
-	p.toBeWritten = append(
-		p.toBeWritten, pstore.Record{
-			HostName:  r.ApplicationId.HostName(),
-			AppName:   appName(r.ApplicationId.Port()),
-			Path:      strings.Replace(r.Info.Path(), "/", "_", -1),
-			Kind:      r.Info.Kind(),
-			Unit:      r.Info.Unit(),
-			Value:     r.Value,
-			Timestamp: r.TimeStamp})
-}
-
-func (p *pstoreHandlerType) StartVisit() {
-	p.ttWriter = &timeTakenWriter{Writer: p.writer}
-	p.startTime = time.Now()
-}
-
-func (p *pstoreHandlerType) EndVisit() {
-	p.flush()
-	totalTimeSpent := time.Now().Sub(p.startTime)
-	p.timeSpentWritingDist.Add(p.ttWriter.TimeTaken)
-	p.totalTimeSpentDist.Add(totalTimeSpent)
-	p.timeSpentCollectingDist.Add(totalTimeSpent - p.ttWriter.TimeTaken)
-}
-
-func (p *pstoreHandlerType) Visit(
-	theStore *store.Store, endpointId *collector.Endpoint) error {
-
-	// Get the last known values for this endpoint creating the map
-	// if necessary.
-	p.lastValuesThisEndpoint = p.lastValues[endpointId]
-	if p.lastValuesThisEndpoint == nil {
-		p.lastValuesThisEndpoint = make(
-			map[*store.MetricInfo]interface{})
-		p.lastValues[endpointId] = p.lastValuesThisEndpoint
-	}
-
-	// Get the latest values to write, but get only the
-	// values that changed.
-	theStore.LatestByEndpoint(endpointId, p)
-
-	// If we have enough values to write,
-	// write them out to persistent storage.
-	if len(p.toBeWritten) >= *fPStoreBatchSize {
-		p.flush()
-	}
-	p.logVisit()
-	return nil
-}
-
-func (p *pstoreHandlerType) flush() {
-	if len(p.toBeWritten) == 0 {
-		return
-	}
-	startTime := time.Now()
-	err := p.ttWriter.Write(p.toBeWritten)
-	p.perBatchWriteDist.Add(time.Now().Sub(startTime))
-
-	if err != nil {
-		p.logWriteError(err)
-	} else {
-		p.logWrite(len(p.toBeWritten))
-	}
-	p.perBatchWriteDist.Add(time.Now().Sub(startTime))
-
-	// Make toBeWritten be empty while saving on memory allocation
-	p.toBeWritten = p.toBeWritten[:0]
-}
-
-func (p *pstoreHandlerType) RegisterMetrics() {
-	tricorder.RegisterMetric(
-		"writer/writeTimePerBatch",
-		p.perBatchWriteDist,
-		units.Millisecond,
-		"Time spent writing each batch")
-	tricorder.RegisterMetric(
-		"writer/timeSpentCollecting",
-		p.timeSpentCollectingDist,
-		units.Second,
-		"Time spent collecting metrics to write to persistent storage per sweep")
-	tricorder.RegisterMetric(
-		"writer/timeSpentWriting",
-		p.timeSpentWritingDist,
-		units.Second,
-		"Time spent writing metrics to persistent storage per sweep")
-	tricorder.RegisterMetric(
-		"writer/totalTimeSpent",
-		p.totalTimeSpentDist,
-		units.Second,
-		"total time spent per sweep")
-	var data pstoreHandlerData
-	region := tricorder.RegisterRegion(func() { p.collectData(&data) })
-	tricorder.RegisterMetricInRegion(
-		"writer/metricsWritten",
-		&data.MetricsWritten,
-		region,
-		units.None,
-		"Number of metrics written to persistent storage")
-	tricorder.RegisterMetricInRegion(
-		"writer/writeAttempts",
-		&data.WriteAttempts,
-		region,
-		units.None,
-		"Number of attempts to write to persistent storage")
-	tricorder.RegisterMetricInRegion(
-		"writer/successfulWrites",
-		&data.SuccessfulWrites,
-		region,
-		units.None,
-		"Number of successful writes to persistent storage")
-	tricorder.RegisterMetricInRegion(
-		"writer/successfulWriteRatio",
-		func() float64 {
-			return float64(data.SuccessfulWrites) / float64(data.WriteAttempts)
-		},
-		region,
-		units.None,
-		"Ratio of successful writes to write attempts")
-	tricorder.RegisterMetricInRegion(
-		"writer/lastWriteError",
-		&data.LastWriteError,
-		region,
-		units.None,
-		"Last write error")
-	tricorder.RegisterMetricInRegion(
-		"writer/endpointsVisited",
-		&data.EndpointsVisited,
-		region,
-		units.None,
-		"Number of endpoints visited")
-	tricorder.RegisterMetricInRegion(
-		"writer/averageMetricsPerEndpoint",
-		func() float64 {
-			return float64(data.MetricsWritten) / float64(data.EndpointsVisited)
-		},
-		region,
-		units.None,
-		"Average metrics written per endpoint per cycle.")
-	tricorder.RegisterMetricInRegion(
-		"writer/averageMetricsPerBatch",
-		func() float64 {
-			return float64(data.MetricsWritten) / float64(data.SuccessfulWrites)
-		},
-		region,
-		units.None,
-		"Average metrics written per batch.")
-}
-
-func (p *pstoreHandlerType) logWrite(numWritten int) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-	p.stats.MetricsWritten += int64(numWritten)
-	p.stats.WriteAttempts++
-	p.stats.SuccessfulWrites++
-}
-
-func (p *pstoreHandlerType) logWriteError(err error) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-	p.stats.WriteAttempts++
-	p.stats.LastWriteError = err.Error()
-}
-
-func (p *pstoreHandlerType) logVisit() {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-	p.stats.EndpointsVisited++
-}
-
-// collectData collects metrics about this instance.
-// Although pstoreHandlerType instances are not threadsafe, the collectData
-// method is threadsafe.
-func (p *pstoreHandlerType) collectData(data *pstoreHandlerData) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-	*data = p.stats
-}
-
 // logger implements the scotty.Logger interface
 // keeping track of collection statistics
 type loggerType struct {
-	Store *store.Store
+	Store               *store.Store
+	NoBlockPStore       *pstore.NoBlockPStore
+	AppList             *datastructs.ApplicationList
+	AppStats            *datastructs.ApplicationStatuses
+	ConnectionErrors    *connectionErrorsType
+	CollectionTimesDist *tricorder.CumulativeDistribution
+	ChangedMetricsDist  *tricorder.CumulativeDistribution
 }
 
 func (l *loggerType) LogStateChange(
 	e *collector.Endpoint, oldS, newS *collector.State) {
 	if newS.Status() == collector.Synced {
-		gCollectionTimesDist.Add(
+		l.CollectionTimesDist.Add(
 			newS.TimeSpentConnecting() + newS.TimeSpentPolling() + newS.TimeSpentWaitingToConnect() + newS.TimeSpentWaitingToPoll())
 	}
-	if oldS != nil {
-		gStatusCounts.Update(oldS.Status(), newS.Status())
-	} else {
-		gStatusCounts.Update(collector.Unknown, newS.Status())
-	}
-	gApplicationStats.Update(e, newS)
+	l.AppStats.Update(e, newS)
 }
 
 func (l *loggerType) LogError(e *collector.Endpoint, err error, state *collector.State) {
 	if err == nil {
-		gConnectionErrors.Clear(e)
+		l.ConnectionErrors.Clear(e)
 	} else {
-		gConnectionErrors.Set(e, err, state.Timestamp())
+		l.ConnectionErrors.Set(e, err, state.Timestamp())
 	}
 }
 
@@ -538,17 +173,17 @@ func (l *loggerType) LogResponse(
 			return ametric.Kind != types.Dist
 		},
 		func(added *store.Record) {
-			gNoBlockPStore.Write(&pstore.Record{
+			l.NoBlockPStore.Write(&pstore.Record{
 				HostName:  added.ApplicationId.HostName(),
-				AppName:   appName(added.ApplicationId.Port()),
+				AppName:   l.AppList.ByPort(added.ApplicationId.Port()).Name(),
 				Path:      strings.Replace(added.Info.Path(), "/", "_", -1),
 				Kind:      added.Info.Kind(),
 				Unit:      added.Info.Unit(),
 				Value:     added.Value,
 				Timestamp: added.TimeStamp})
 		})
-	gApplicationStats.LogChangedMetricCount(e, added)
-	gChangedMetricsPerEndpointDist.Add(float64(added))
+	l.AppStats.LogChangedMetricCount(e, added)
+	l.ChangedMetricsDist.Add(float64(added))
 }
 
 type gzipResponseWriter struct {
@@ -686,12 +321,13 @@ func encodeJson(w io.Writer, data interface{}, pretty bool) {
 
 // errorHandler provides the api/errors requests.
 type errorHandler struct {
+	ConnectionErrors *connectionErrorsType
 }
 
-func (h errorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *errorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.ParseForm()
 	w.Header().Set("Content-Type", "application/json")
-	encodeJson(w, gConnectionErrors.GetErrors(), r.Form.Get("format") == "text")
+	encodeJson(w, h.ConnectionErrors.GetErrors(), r.Form.Get("format") == "text")
 }
 
 func httpError(w http.ResponseWriter, status int) {
@@ -706,10 +342,12 @@ func httpError(w http.ResponseWriter, status int) {
 
 // byEndpointHandler handles serving api/hosts requests
 type byEndpointHandler struct {
+	HostsPortsAndStore *datastructs.HostsPortsAndStore
+	AppList            *datastructs.ApplicationList
 }
 
-func (h byEndpointHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	metricStore, endpoints := gHostsPortsAndStore.Get()
+func (h *byEndpointHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	metricStore, endpoints := h.HostsPortsAndStore.Get()
 	r.ParseForm()
 	w.Header().Set("Content-Type", "application/json")
 	hostNameAndPath := strings.SplitN(r.URL.Path, "/", 3)
@@ -729,7 +367,7 @@ func (h byEndpointHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		history = 60
 	}
-	app := gApplicationList.ByName(name)
+	app := h.AppList.ByName(name)
 	if app == nil {
 		httpError(w, 404)
 		return
@@ -745,17 +383,9 @@ func (h byEndpointHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	encodeJson(w, data, r.Form.Get("format") == "text")
 }
 
-type timeTakenWriter struct {
-	pstore.Writer
-	TimeTaken time.Duration
-}
-
-func (t *timeTakenWriter) Write(records []pstore.Record) error {
-	start := time.Now()
-	result := t.Writer.Write(records)
-	t.TimeTaken += time.Now().Sub(start)
-	return result
-}
+var (
+	aWriteError = errors.New("A bad write error.")
+)
 
 // A fake pstore.Writer implementation. This fake simply stalls 50ms with each
 // write.
@@ -790,24 +420,21 @@ func newWriter() (result pstore.Writer, err error) {
 	return kafka.NewWriter(&config)
 }
 
-func updateEndpoints(machines *mdb.Mdb) {
-	_, endpoints := gHostsPortsAndStore.Get()
-	newEndpoints := make(datastructs.HostsAndPorts)
-	addEndpoints(machines, endpoints, newEndpoints)
-	gHostsPortsAndStore.Update(newEndpoints)
-}
-
-func addEndpoints(
-	machines *mdb.Mdb, origHostsAndPorts, hostsAndPorts datastructs.HostsAndPorts) {
-	apps := gApplicationList.All()
-	for _, machine := range machines.Machines {
-		for _, app := range apps {
-			hostsAndPorts.AddIfAbsent(origHostsAndPorts, machine.Hostname, app.Port())
-		}
+func createNoBlockPStore() *pstore.NoBlockPStore {
+	writer, err := newWriter()
+	if err != nil {
+		log.Fatal(err)
 	}
+	result := pstore.NewNoBlockPStore(
+		writer,
+		*fPStoreBatchSize,
+		*fPStoreChannelCapacity,
+		time.Second)
+	result.RegisterMetrics()
+	return result
 }
 
-func initApplicationList() {
+func createApplicationList() *datastructs.ApplicationList {
 	f, err := os.Open(*fAppFile)
 	if err != nil {
 		log.Fatal(err)
@@ -817,79 +444,92 @@ func initApplicationList() {
 	if err := builder.ReadConfig(f); err != nil {
 		log.Fatal(err)
 	}
-	gApplicationList = builder.Build()
+	return builder.Build()
 }
 
-func main() {
-	tricorder.RegisterFlags()
-	flag.Parse()
-	var mdbChannel <-chan *mdb.Mdb
-	collector.SetConcurrentPolls(*fPollCount)
-	collector.SetConcurrentConnects(*fConnectionCount)
-	firstEndpoints := make(datastructs.HostsAndPorts)
-	realEndpoints := (*fHostFile == "")
-	writer, err := newWriter()
+func computePageCount() int {
+	totalMemoryToUse, err := sysmemory.TotalMemoryToUse()
 	if err != nil {
 		log.Fatal(err)
 	}
-	// TODO: Create command line params.
-	gNoBlockPStore = pstore.NewNoBlockPStore(
-		writer, *fPStoreBatchSize, 1000000, time.Second)
-	gNoBlockPStore.RegisterMetrics()
-	// pstoreHandler := newPStoreHandler(writer)
-	if !realEndpoints {
-		f, err := os.Open(*fHostFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer f.Close()
-		var hostAndPort string
-		var endpointNames []string
-		var endpointPorts []int
-		_, err = fmt.Fscanln(f, &hostAndPort)
-		for ; err != io.EOF; _, err = fmt.Fscanln(f, &hostAndPort) {
-			if err != nil {
-				continue
-			}
-			splits := strings.SplitN(hostAndPort, ":", 2)
-			port, _ := strconv.Atoi(splits[1])
-			endpointNames = append(endpointNames, splits[0])
-			endpointPorts = append(endpointPorts, port)
-		}
-		for i := 0; i < totalNumberOfEndpoints; i++ {
-			name, port := endpointNameAndPort(endpointNames, endpointPorts, i)
-			if i%1000 == 37 {
-				port = 7776
-			}
-			firstEndpoints.AddIfAbsent(nil, name, port)
-		}
-		builder := datastructs.NewApplicationListBuilder()
-		builder.Add(6910, "Health Metrics")
-		builder.Add(7776, "Non existent App")
-		gApplicationList = builder.Build()
-	} else {
-		initApplicationList()
-		mdbChannel = mdbd.StartMdbDaemon(*fMdbFile, log.New(os.Stderr, "", log.LstdFlags))
-		addEndpoints(<-mdbChannel, nil, firstEndpoints)
+	if totalMemoryToUse > 0 {
+		return int(totalMemoryToUse / uint64(*fBytesPerPage))
 	}
+	return *fPageCount
+}
+
+func updateEndpoints(
+	machines *mdb.Mdb,
+	apps []*datastructs.Application,
+	hostsPortsAndStore *datastructs.HostsPortsAndStore) {
+	_, endpoints := hostsPortsAndStore.Get()
+	newEndpoints := make(datastructs.HostsAndPorts)
+	addEndpoints(machines, apps, endpoints, newEndpoints)
+	hostsPortsAndStore.Update(newEndpoints)
+}
+
+func addEndpoints(
+	machines *mdb.Mdb,
+	apps []*datastructs.Application,
+	origHostsAndPorts,
+	hostsAndPorts datastructs.HostsAndPorts) {
+	for _, machine := range machines.Machines {
+		for _, app := range apps {
+			hostsAndPorts.AddIfAbsent(origHostsAndPorts, machine.Hostname, app.Port())
+		}
+	}
+}
+
+func initHostsPortsAndStore(
+	appList *datastructs.ApplicationList,
+	result *datastructs.HostsPortsAndStore) {
+	mdbChannel := mdbd.StartMdbDaemon(
+		*fMdbFile, log.New(os.Stderr, "", log.LstdFlags))
+	firstEndpoints := make(datastructs.HostsAndPorts)
+	addEndpoints(<-mdbChannel, appList.All(), nil, firstEndpoints)
+	fmt.Println("Initialization started.")
+	// Value interface + float64 = 24 bytes
+	result.Init(
+		(*fBytesPerPage)/24, computePageCount(), firstEndpoints)
+	fmt.Println("Initialization complete.")
+	firstStore, _ := result.Get()
+	firstStore.RegisterMetrics()
+	// Endpoint refresher goroutine
+	go func() {
+		for {
+			updateEndpoints(<-mdbChannel, appList.All(), result)
+		}
+	}()
+}
+
+func startCollector(
+	hostsPortsAndStore *datastructs.HostsPortsAndStore,
+	noBlockPStore *pstore.NoBlockPStore,
+	appList *datastructs.ApplicationList,
+	appStats *datastructs.ApplicationStatuses,
+	connectionErrors *connectionErrorsType) {
+	collector.SetConcurrentPolls(*fPollCount)
+	collector.SetConcurrentConnects(*fConnectionCount)
+
+	sweepDurationDist := tricorder.NewGeometricBucketer(1, 100000.0).NewCumulativeDistribution()
+	collectionTimesDist := tricorder.NewGeometricBucketer(1e-4, 100.0).NewCumulativeDistribution()
+	changedMetricsPerEndpointDist := tricorder.NewGeometricBucketer(1.0, 10000.0).NewCumulativeDistribution()
+
 	tricorder.RegisterMetric(
 		"collector/collectionTimes",
-		gCollectionTimesDist,
+		collectionTimesDist,
 		units.Second,
 		"Collection Times")
 	tricorder.RegisterMetric(
 		"collector/changedMetricsPerEndpoint",
-		gChangedMetricsPerEndpointDist,
+		changedMetricsPerEndpointDist,
 		units.None,
 		"Changed metrics per sweep")
-	sweepDurationDist := tricorder.NewGeometricBucketer(1, 100000.0).NewCumulativeDistribution()
 	tricorder.RegisterMetric(
 		"collector/sweepDuration",
 		sweepDurationDist,
 		units.Millisecond,
 		"Sweep duration")
-	gStatusCounts.RegisterMetrics()
-	// pstoreHandler.RegisterMetrics()
 	programStartTime := time.Now()
 	tricorder.RegisterMetric(
 		"collector/elapsedTime",
@@ -898,43 +538,19 @@ func main() {
 		},
 		units.Second,
 		"elapsed time")
-	tricorder.RegisterMetric(
-		"collector/activeEndpointCount",
-		func() int {
-			_, endpoints := gHostsPortsAndStore.Get()
-			return len(endpoints)
-		},
-		units.Second,
-		"elapsed time")
 
-	fmt.Println("Initialization started.")
-	// Value interface + float64 = 24 bytes
-	totalMemoryToUse, err := sysmemory.TotalMemoryToUse()
-	if err != nil {
-		log.Fatal(err)
-	}
-	if totalMemoryToUse > 0 {
-		*fPageCount = int(totalMemoryToUse / uint64(*fBytesPerPage))
-	}
-	gHostsPortsAndStore.Init(
-		(*fBytesPerPage)/24, *fPageCount, firstEndpoints)
-	fmt.Println("Initialization complete.")
-	firstStore, _ := gHostsPortsAndStore.Get()
-	firstStore.RegisterMetrics()
-	// Endpoint refresher goroutine
-	if realEndpoints {
-		go func() {
-			for {
-				updateEndpoints(<-mdbChannel)
-			}
-		}()
-	}
-
-	// Metric collection goroutine. Collect metrics every minute.
+	// Metric collection goroutine. Collect metrics periodically.
 	go func() {
 		for {
-			metricStore, endpoints := gHostsPortsAndStore.Get()
-			logger := &loggerType{Store: metricStore}
+			metricStore, endpoints := hostsPortsAndStore.Get()
+			logger := &loggerType{
+				Store:               metricStore,
+				NoBlockPStore:       noBlockPStore,
+				AppList:             appList,
+				AppStats:            appStats,
+				ConnectionErrors:    connectionErrors,
+				CollectionTimesDist: collectionTimesDist,
+				ChangedMetricsDist:  changedMetricsPerEndpointDist}
 			sweepTime := time.Now()
 			for _, endpoint := range endpoints {
 				endpoint.Poll(sweepTime, logger)
@@ -947,22 +563,45 @@ func main() {
 		}
 	}()
 
+}
+
+func main() {
+	tricorder.RegisterFlags()
+	flag.Parse()
+	noBlockPStore := createNoBlockPStore()
+	applicationList := createApplicationList()
+	applicationStats := datastructs.NewApplicationStatuses()
+	connectionErrors := newConnectionErrorsType()
+	var hostsPortsAndStore datastructs.HostsPortsAndStore
+	initHostsPortsAndStore(applicationList, &hostsPortsAndStore)
+	startCollector(
+		&hostsPortsAndStore,
+		noBlockPStore,
+		applicationList,
+		applicationStats,
+		connectionErrors)
+
 	http.Handle(
 		"/showAllApps",
 		gzipHandler{&showallapps.Handler{
-			AS:  gApplicationStats,
-			HPS: &gHostsPortsAndStore,
-			AL:  gApplicationList,
+			AS:  applicationStats,
+			HPS: &hostsPortsAndStore,
+			AL:  applicationList,
 		}})
 
 	http.Handle(
 		"/api/hosts/",
 		http.StripPrefix(
 			"/api/hosts/",
-			gzipHandler{byEndpointHandler{}}))
+			gzipHandler{&byEndpointHandler{
+				HostsPortsAndStore: &hostsPortsAndStore,
+				AppList:            applicationList,
+			}}))
 	http.Handle(
 		"/api/errors/",
-		gzipHandler{errorHandler{}},
+		gzipHandler{&errorHandler{
+			ConnectionErrors: connectionErrors,
+		}},
 	)
 	if err := http.ListenAndServe(":8187", nil); err != nil {
 		log.Fatal(err)

--- a/pstore/api.go
+++ b/pstore/api.go
@@ -2,8 +2,11 @@
 package pstore
 
 import (
+	"github.com/Symantec/tricorder/go/tricorder"
 	"github.com/Symantec/tricorder/go/tricorder/types"
 	"github.com/Symantec/tricorder/go/tricorder/units"
+	"sync"
+	"time"
 )
 
 // Record represents one value of one metric in persistent storage.
@@ -31,4 +34,50 @@ type Writer interface {
 
 	// Write writes given collection of records to persistent storage
 	Write(records []Record) error
+}
+
+// NoBlockPStore lets clients send metric values asynchronously to an
+// existing Writer.
+type NoBlockPStore struct {
+	inChannel          chan Record
+	batchSize          int
+	channelSize        int
+	flushDelay         time.Duration
+	writer             Writer
+	perMetricWriteDist *tricorder.CumulativeDistribution
+	batchSizeDist      *tricorder.CumulativeDistribution
+	lock               sync.Mutex
+	data               noBlockPStoreDataType
+}
+
+// NewNoBlockPStore creates a new NoBlockPStore.
+// writer is the existing writer to wrap.
+// batchSize is the desired number of metric values to send at once to writer.
+// channelSize is the fixed size of the queue buffering metric values.
+// flushDelay indicates how long the returned NoBlockPStore instance must be
+// idle before it flushes unwritten metrics that do not make a complete batch
+// out to the underlying Writer.
+func NewNoBlockPStore(
+	writer Writer,
+	batchSize,
+	channelSize int,
+	flushDelay time.Duration) *NoBlockPStore {
+	return newNoBlockPStore(writer, batchSize, channelSize, flushDelay)
+}
+
+// Write writes the contents of record to the underlying writer asynchronously.
+// Write adds the contents of record to this instance's queue and returns
+// immediately writing the contents of record to the underlying writer
+// sometime later.
+// If the queue is already full or if the underlying writer does not support
+// the kind of metric value in record, Write simply ignores the request.
+func (n *NoBlockPStore) Write(record *Record) {
+	n.write(record)
+}
+
+// RegisterMetrics registers the metrics for this instance. Generally, each
+// application will have only one such instance. It is an error to call
+// RegisterMetrics on multiple instances.
+func (n *NoBlockPStore) RegisterMetrics() error {
+	return n.registerMetrics()
 }

--- a/pstore/pstore.go
+++ b/pstore/pstore.go
@@ -1,0 +1,206 @@
+package pstore
+
+import (
+	"github.com/Symantec/tricorder/go/tricorder"
+	"github.com/Symantec/tricorder/go/tricorder/units"
+	"time"
+)
+
+var (
+	gWriteTimeBucketer = tricorder.NewGeometricBucketer(1e-4, 1000.0)
+	gBatchSizeBucketer = tricorder.NewGeometricBucketer(1.0, 1e9)
+)
+
+type noBlockPStoreDataType struct {
+	RequestCount           uint64
+	SkippedCount           uint64
+	TotalBatchCount        uint64
+	UnsuccessfulBatchCount uint64
+	LastBatchWriteError    string
+}
+
+func newNoBlockPStore(
+	writer Writer,
+	batchSize, channelSize int,
+	flushDelay time.Duration) *NoBlockPStore {
+	result := &NoBlockPStore{
+		inChannel:          make(chan Record, channelSize),
+		batchSize:          batchSize,
+		channelSize:        channelSize,
+		writer:             writer,
+		flushDelay:         flushDelay,
+		perMetricWriteDist: gWriteTimeBucketer.NewCumulativeDistribution(),
+		batchSizeDist:      gBatchSizeBucketer.NewCumulativeDistribution(),
+	}
+	go result.loop()
+	return result
+}
+
+func (n *NoBlockPStore) write(record *Record) {
+	if !n.writer.IsTypeSupported(record.Kind) {
+		return
+	}
+	select {
+	case n.inChannel <- *record:
+		n.logAcceptedRequest()
+	default:
+		n.logSkippedRequest()
+	}
+}
+
+func (n *NoBlockPStore) collectData(data *noBlockPStoreDataType) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	*data = n.data
+}
+
+func (n *NoBlockPStore) logSkippedRequest() {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	n.data.RequestCount++
+	n.data.SkippedCount++
+}
+
+func (n *NoBlockPStore) logAcceptedRequest() {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	n.data.RequestCount++
+}
+
+func (n *NoBlockPStore) logBatchError(err error) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	n.data.TotalBatchCount++
+	n.data.UnsuccessfulBatchCount++
+	n.data.LastBatchWriteError = err.Error()
+}
+
+func (n *NoBlockPStore) logBatchSuccess() {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	n.data.TotalBatchCount++
+}
+
+func (n *NoBlockPStore) flush(records []Record) {
+	now := time.Now()
+	err := n.writer.Write(records)
+	rlen := len(records)
+	n.perMetricWriteDist.Add(time.Now().Sub(now) / time.Duration(rlen))
+	n.batchSizeDist.Add(float64(rlen))
+	if err != nil {
+		n.logBatchError(err)
+	} else {
+		n.logBatchSuccess()
+	}
+}
+
+func (n *NoBlockPStore) loop() {
+	batch := make([]Record, n.batchSize)
+	idx := 0
+	for {
+		if idx == n.batchSize {
+			n.flush(batch)
+			idx = 0
+		}
+		if idx == 0 {
+			batch[idx] = <-n.inChannel
+			idx++
+		} else {
+			select {
+			case batch[idx] = <-n.inChannel:
+				idx++
+			case <-time.After(n.flushDelay):
+				n.flush(batch[:idx])
+				idx = 0
+			}
+		}
+	}
+}
+
+func (n *NoBlockPStore) registerMetrics() (err error) {
+	if err = tricorder.RegisterMetric(
+		"writer/writeTimePerMetric",
+		n.perMetricWriteDist,
+		units.Millisecond,
+		"Time spent writing each metric"); err != nil {
+		return
+	}
+	if err = tricorder.RegisterMetric(
+		"writer/batchSizeDist",
+		n.batchSizeDist,
+		units.None,
+		"Metrics per batch"); err != nil {
+		return
+	}
+	if err = tricorder.RegisterMetric(
+		"writer/maxBatchSize",
+		&n.batchSize,
+		units.None,
+		"Max number of metrics per batch."); err != nil {
+		return
+	}
+	if err = tricorder.RegisterMetric(
+		"writer/channelCapacity",
+		&n.channelSize,
+		units.None,
+		"Channel capacity."); err != nil {
+		return
+	}
+	if err = tricorder.RegisterMetric(
+		"writer/channelLoad",
+		func() int { return len(n.inChannel) },
+		units.None,
+		"Channel load."); err != nil {
+		return
+	}
+	if err = tricorder.RegisterMetric(
+		"writer/flushDelay",
+		&n.flushDelay,
+		units.Second,
+		"Flush delay."); err != nil {
+		return
+	}
+	var data noBlockPStoreDataType
+	region := tricorder.RegisterRegion(func() { n.collectData(&data) })
+	if err = tricorder.RegisterMetricInRegion(
+		"writer/requestCount",
+		&data.RequestCount,
+		region,
+		units.None,
+		"Total number of requests to write an individual metric. Does not include requests to write metrics of an unsupported kind."); err != nil {
+		return
+	}
+	if err = tricorder.RegisterMetricInRegion(
+		"writer/skippedCount",
+		&data.SkippedCount,
+		region,
+		units.None,
+		"Number of requests skipped because the writer was too busy to field all the requests."); err != nil {
+		return
+	}
+	if err = tricorder.RegisterMetricInRegion(
+		"writer/totalBatchCount",
+		&data.TotalBatchCount,
+		region,
+		units.None,
+		"Number of metric batches sent to back end"); err != nil {
+		return
+	}
+	if err = tricorder.RegisterMetricInRegion(
+		"writer/unsuccessfulBatchCount",
+		&data.UnsuccessfulBatchCount,
+		region,
+		units.None,
+		"Number of batches that were not written successfully"); err != nil {
+		return
+	}
+	if err = tricorder.RegisterMetricInRegion(
+		"writer/lastBatchWriteError",
+		&data.LastBatchWriteError,
+		region,
+		units.None,
+		"Last batch write error"); err != nil {
+		return
+	}
+	return
+}


### PR DESCRIPTION
In this PR I simplify the mechanism of writing to LMM.

Instead of periodically crawling the in memory scotty datastore to write metrics to LMM, I write metrics to LMM as soon as scotty receives. I use a buffered channel, to prevent LMM latency issues from slowing down the metric collection process. Goroutines receiving metrics write to the channel and move on, while another goroutine reads from the channel and writes requests to LMM sometime later.

This change offers the following advantages over what I had before:
- Simplicity of mechanism - It is easy to reason that the same metrics received from an endpoint are the same metrics written to LMM (before writes to LMM could skip values unknowingly if LMM was too slow).
- Cleaner metrics - It is easy to convey precise metrics that show whether LMM is keeping up with the load or if values are getting dropped because the buffered channel is full.
- Less code complexity - All the extra code needed to crawl the in memory database and arrange batched writes to LMM is gone.
