### PR TITLE
Make endpointId be an interface.

### DIFF
--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -214,8 +214,10 @@ func (p *pstoreHandlerType) EndVisit() {
 }
 
 func (p *pstoreHandlerType) Visit(
-	theStore *store.Store, endpointId *collector.Endpoint) error {
+	theStore *store.Store, endpointId interface{}) error {
 	iterators := theStore.Iterators(endpointId)
+	hostName := endpointId.(*collector.Endpoint).HostName()
+	port := endpointId.(*collector.Endpoint).Port()
 
 	for i := range iterators {
 		info := iterators[i].Info()
@@ -230,8 +232,8 @@ func (p *pstoreHandlerType) Visit(
 			}
 			p.iteratorsBeingWritten[p.idx] = iterators[i]
 			p.toBeWritten[p.idx] = pstore.Record{
-				HostName:  endpointId.HostName(),
-				Tags:      pstore.TagGroup{pstore.TagAppName: p.appList.ByPort(endpointId.Port()).Name()},
+				HostName:  hostName,
+				Tags:      pstore.TagGroup{pstore.TagAppName: p.appList.ByPort(port).Name()},
 				Path:      strings.Replace(info.Path(), "/", "_", -1),
 				Kind:      info.Kind(),
 				Unit:      info.Unit(),

--- a/store/api.go
+++ b/store/api.go
@@ -2,7 +2,6 @@
 package store
 
 import (
-	"github.com/Symantec/scotty"
 	trimessages "github.com/Symantec/tricorder/go/tricorder/messages"
 	"github.com/Symantec/tricorder/go/tricorder/types"
 	"github.com/Symantec/tricorder/go/tricorder/units"
@@ -46,7 +45,7 @@ func (m *MetricInfo) Bits() int {
 // Record represents one value for one particular metric at a particular
 // time.
 type Record struct {
-	ApplicationId *scotty.Endpoint
+	ApplicationId interface{}
 	Info          *MetricInfo
 	TimeStamp     float64
 	Value         interface{}
@@ -71,7 +70,7 @@ func AppendTo(result *[]*Record) Appender {
 type Visitor interface {
 
 	// Called once for each endpoint registered with the Store instance
-	Visit(store *Store, endpoint *scotty.Endpoint) error
+	Visit(store *Store, endpoint interface{}) error
 }
 
 type Builder struct {
@@ -83,7 +82,7 @@ type Builder struct {
 func NewBuilder(
 	valueCountPerPage, pageCount int) *Builder {
 	store := &Store{
-		byApplication:    make(map[*scotty.Endpoint]*timeSeriesCollectionType),
+		byApplication:    make(map[interface{}]*timeSeriesCollectionType),
 		supplier:         newPageSupplierType(valueCountPerPage, pageCount),
 		totalPageCount:   pageCount,
 		maxValuesPerPage: valueCountPerPage,
@@ -94,7 +93,7 @@ func NewBuilder(
 
 // RegisterEndpoint registers a endpoint with the store being built.
 // RegisterEndpoint panics if endpoint is already registered.
-func (b *Builder) RegisterEndpoint(endpointId *scotty.Endpoint) {
+func (b *Builder) RegisterEndpoint(endpointId interface{}) {
 	b.registerEndpoint(endpointId)
 }
 
@@ -135,7 +134,7 @@ func (i *Iterator) Commit() {
 // Client must register all the endpoints with the Store
 // instance before storing any metrics.
 type Store struct {
-	byApplication    map[*scotty.Endpoint]*timeSeriesCollectionType
+	byApplication    map[interface{}]*timeSeriesCollectionType
 	supplier         *pageSupplierType
 	totalPageCount   int
 	maxValuesPerPage int
@@ -155,7 +154,7 @@ func (s *Store) NewBuilder() *Builder {
 // same endpointId. However multiple goroutines may call Add() as long as
 // long as each passes a different endpointId.
 func (s *Store) Add(
-	endpointId *scotty.Endpoint,
+	endpointId interface{},
 	timestamp float64, m *trimessages.Metric) bool {
 	return s.add(endpointId, timestamp, m)
 }
@@ -168,7 +167,7 @@ func (s *Store) Add(
 // with the same endpointId. However multiple goroutines may call
 // AddBatch() as long as long as each passes a different endpointId.
 func (s *Store) AddBatch(
-	endpointId *scotty.Endpoint,
+	endpointId interface{},
 	timestamp float64,
 	metricList trimessages.MetricList,
 	filter func(*trimessages.Metric) bool) int {
@@ -186,7 +185,7 @@ func (s *Store) AddBatch(
 // same path. This could happen if the definition of a metric changes.
 func (s *Store) ByNameAndEndpoint(
 	path string,
-	endpointId *scotty.Endpoint,
+	endpointId interface{},
 	start, end float64,
 	result Appender) {
 	s.byNameAndEndpoint(
@@ -204,7 +203,7 @@ func (s *Store) ByNameAndEndpoint(
 // same path. This could happen if the definition of a metric changes.
 func (s *Store) ByPrefixAndEndpoint(
 	prefix string,
-	endpointId *scotty.Endpoint,
+	endpointId interface{},
 	start, end float64,
 	result Appender) {
 	s.byPrefixAndEndpoint(
@@ -220,7 +219,7 @@ func (s *Store) ByPrefixAndEndpoint(
 // then sorted by time in descending order within each metric.
 // The endpoints and metrics are in no particular order.
 func (s *Store) ByEndpoint(
-	endpointId *scotty.Endpoint,
+	endpointId interface{},
 	start, end float64,
 	result Appender) {
 	s.byEndpoint(endpointId, start, end, result)
@@ -228,7 +227,7 @@ func (s *Store) ByEndpoint(
 
 // Iterators returns all the Iterators for all the time series for the
 // given endpoint.
-func (s *Store) Iterators(endpointId *scotty.Endpoint) []*Iterator {
+func (s *Store) Iterators(endpointId interface{}) []*Iterator {
 	return s.iterators(endpointId)
 }
 
@@ -236,7 +235,7 @@ func (s *Store) Iterators(endpointId *scotty.Endpoint) []*Iterator {
 // given endpoint.
 // LatestByEndpoint appends the records to result in no particular order.
 func (s *Store) LatestByEndpoint(
-	endpointId *scotty.Endpoint,
+	endpointId interface{},
 	result Appender) {
 	s.latestByEndpoint(endpointId, result)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"container/list"
-	"github.com/Symantec/scotty"
 	"github.com/Symantec/tricorder/go/tricorder"
 	trimessages "github.com/Symantec/tricorder/go/tricorder/messages"
 	"github.com/Symantec/tricorder/go/tricorder/units"
@@ -109,7 +108,7 @@ func (p pageType) IsFull() bool {
 }
 
 func (p pageType) Fetch(
-	applicationId *scotty.Endpoint,
+	applicationId interface{},
 	id *MetricInfo,
 	start, end float64,
 	result Appender) (keepGoing bool) {
@@ -346,7 +345,7 @@ func (t *timeSeriesType) Add(
 }
 
 func (t *timeSeriesType) Fetch(
-	applicationId *scotty.Endpoint,
+	applicationId interface{},
 	start, end float64,
 	result Appender) {
 	t.lock.Lock()
@@ -365,7 +364,7 @@ func (t *timeSeriesType) latestPage() *pageType {
 }
 
 type timeSeriesCollectionType struct {
-	applicationId   *scotty.Endpoint
+	applicationId   interface{}
 	lock            sync.Mutex
 	timeSeries      map[*MetricInfo]*timeSeriesType
 	metricInfoStore metricInfoStoreType
@@ -373,7 +372,7 @@ type timeSeriesCollectionType struct {
 }
 
 func newTimeSeriesCollectionType(
-	app *scotty.Endpoint) *timeSeriesCollectionType {
+	app interface{}) *timeSeriesCollectionType {
 	result := &timeSeriesCollectionType{
 		applicationId: app,
 		timeSeries:    make(map[*MetricInfo]*timeSeriesType),
@@ -621,7 +620,7 @@ func (l *recordListType) Append(r *Record) {
 	*l = append(*l, &recordCopy)
 }
 
-func (b *Builder) registerEndpoint(endpointId *scotty.Endpoint) {
+func (b *Builder) registerEndpoint(endpointId interface{}) {
 
 	if (*b.store).byApplication[endpointId] != nil {
 		panic("Endpoint already registered")
@@ -647,7 +646,7 @@ func (b *Builder) build() *Store {
 
 func (s *Store) newBuilder() *Builder {
 	store := &Store{
-		byApplication:    make(map[*scotty.Endpoint]*timeSeriesCollectionType),
+		byApplication:    make(map[interface{}]*timeSeriesCollectionType),
 		supplier:         s.supplier,
 		totalPageCount:   s.totalPageCount,
 		maxValuesPerPage: s.maxValuesPerPage,
@@ -656,7 +655,7 @@ func (s *Store) newBuilder() *Builder {
 }
 
 func (s *Store) add(
-	endpointId *scotty.Endpoint,
+	endpointId interface{},
 	timestamp float64, m *trimessages.Metric) bool {
 	return s.byApplication[endpointId].Add(timestamp, m, s.supplier)
 }
@@ -687,7 +686,7 @@ func (i *Iterator) commit() {
 }
 
 func (s *Store) addBatch(
-	endpointId *scotty.Endpoint,
+	endpointId interface{},
 	timestamp float64,
 	metricList trimessages.MetricList,
 	filter func(*trimessages.Metric) bool) int {
@@ -704,13 +703,13 @@ func (s *Store) addBatch(
 	return result
 }
 
-func (s *Store) iterators(endpointId *scotty.Endpoint) []*Iterator {
+func (s *Store) iterators(endpointId interface{}) []*Iterator {
 	return s.byApplication[endpointId].Iterators()
 }
 
 func (s *Store) byNameAndEndpoint(
 	name string,
-	endpointId *scotty.Endpoint,
+	endpointId interface{},
 	start, end float64,
 	result Appender) {
 	s.byApplication[endpointId].ByName(name, start, end, result)
@@ -718,21 +717,21 @@ func (s *Store) byNameAndEndpoint(
 
 func (s *Store) byPrefixAndEndpoint(
 	prefix string,
-	endpointId *scotty.Endpoint,
+	endpointId interface{},
 	start, end float64,
 	result Appender) {
 	s.byApplication[endpointId].ByPrefix(prefix, start, end, result)
 }
 
 func (s *Store) byEndpoint(
-	endpointId *scotty.Endpoint,
+	endpointId interface{},
 	start, end float64,
 	result Appender) {
 	s.byApplication[endpointId].ByPrefix("", start, end, result)
 }
 
 func (s *Store) latestByEndpoint(
-	endpointId *scotty.Endpoint,
+	endpointId interface{},
 	result Appender) {
 	s.byApplication[endpointId].Latest(result)
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -26,7 +26,7 @@ func (s *sumMetricsType) Append(r *store.Record) {
 }
 
 func (s *sumMetricsType) Visit(
-	astore *store.Store, e *scotty.Endpoint) error {
+	astore *store.Store, e interface{}) error {
 	astore.ByEndpoint(e, 0, 1000.0, s)
 	return nil
 }
@@ -34,7 +34,7 @@ func (s *sumMetricsType) Visit(
 type errVisitor int
 
 func (e *errVisitor) Visit(
-	astore *store.Store, ee *scotty.Endpoint) error {
+	astore *store.Store, ee interface{}) error {
 	return kError
 }
 


### PR DESCRIPTION
This is the first of many pull requests to get all my new code in. I waited because I wanted the confidence that I was headed in the right direction.

This first pull request makes endpointId be an interface in the store package. I thought it was weird that my store implementation was tightly coupled with a concrete type associated with our specific way of pulling metrics.
