### PR TITLE
Allow entire hosts to be marked active or inactive.

### DIFF
--- a/apps/scotty/splash/splash.go
+++ b/apps/scotty/splash/splash.go
@@ -46,6 +46,9 @@ func newView(
 	apps []*datastructs.ApplicationStatus) *view {
 	result := &view{}
 	for _, app := range apps {
+		if !app.Active {
+			continue
+		}
 		if app.Down {
 			result.TotalFailedApps++
 		}
@@ -59,7 +62,6 @@ type HtmlWriter interface {
 }
 
 type Handler struct {
-	HPS *datastructs.HostsPortsAndStore
 	AS  *datastructs.ApplicationStatuses
 	Log HtmlWriter
 }
@@ -69,8 +71,7 @@ func (h *Handler) ServeHTTP(
 	writer := bufio.NewWriter(w)
 	defer writer.Flush()
 	w.Header().Set("Content-Type", "text/html")
-	_, hostsAndPorts := h.HPS.Get()
-	result := h.AS.GetAll(hostsAndPorts)
+	result := h.AS.All()
 	fmt.Fprintln(writer, "<html>")
 	fmt.Fprintln(writer, "<title>Scotty status page</title>")
 	fmt.Fprintln(writer, "<body>")

--- a/store/api.go
+++ b/store/api.go
@@ -128,9 +128,6 @@ func (s *Store) RegisterEndpoint(endpointId interface{}) {
 
 // AddBatch adds metric values.
 // AddBatch returns the total number of metric values added.
-// No two goroutines may call AddBatch() on a Store instance concurrently
-// with the same endpointId. However multiple goroutines may call
-// AddBatch() as long as long as each passes a different endpointId.
 func (s *Store) AddBatch(
 	endpointId interface{},
 	timestamp float64,
@@ -225,4 +222,9 @@ func (s *Store) VisitAllEndpoints(v Visitor) error {
 // this instance.
 func (s *Store) RegisterMetrics() error {
 	return s.registerMetrics()
+}
+
+// TODO: Needs a test
+func (s *Store) MarkEndpointInactive(endpointId interface{}) {
+	s.markEndpointInactive(endpointId)
 }


### PR DESCRIPTION
To support stats about inactive hosts cleaned up code by moving auxillary
data structures into datastructs.ApplicationStatuses.
