### PR TITLE
Add active status to timeSeriesCollection type.

### DIFF
--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -449,12 +449,14 @@ func (l *loggerType) LogError(e *collector.Endpoint, err error, state *collector
 func (l *loggerType) LogResponse(
 	e *collector.Endpoint, metrics trimessages.MetricList, state *collector.State) {
 	ts := trimessages.TimeToFloat(state.Timestamp())
-	added := l.Store.AddBatch(
+	added, ok := l.Store.AddBatch(
 		e,
 		ts,
 		metrics)
-	l.AppStats.LogChangedMetricCount(e, added)
-	l.ChangedMetricsDist.Add(float64(added))
+	if ok {
+		l.AppStats.LogChangedMetricCount(e, added)
+		l.ChangedMetricsDist.Add(float64(added))
+	}
 }
 
 type gzipResponseWriter struct {

--- a/datastructs/api.go
+++ b/datastructs/api.go
@@ -56,10 +56,9 @@ func (a *ApplicationStatus) Staleness() time.Duration {
 type ApplicationStatuses struct {
 	appList *ApplicationList
 	// A function must hold this lock when changing the status
-	// (active vs. inactive) of the endpoints or when adding new
-	// endpoints to ensure that when it returns, all of the time series
-	// of each inactive endpoint are also inactive and that
-	// all endpoints in this instance are also in the current store.
+	// (active vs. inactive) of the endpoints to ensure that when it
+	// returns, the status of each endpoint matches the status of the
+	// corresponding time series collection in the current store.
 	// If this lock is acquired, it must be acquired before the normal
 	// lock for this instance.
 	statusChangeLock sync.Mutex

--- a/store/api.go
+++ b/store/api.go
@@ -157,7 +157,7 @@ func (s *Store) RegisterEndpoint(endpointId interface{}) {
 
 // AddBatch adds metric values.
 // AddBatch returns the total number of metric values added including any
-// inactive flags.
+// inactive flags. If endpoint is inactive, AddBatch returns ok = false.
 // AddBatch uses timestamp for all new values in metricList.
 // timestamp is seconds since Jan 1, 1970 GMT.
 // If a time series already in the given endpoint does not have a new value
@@ -169,7 +169,7 @@ func (s *Store) RegisterEndpoint(endpointId interface{}) {
 func (s *Store) AddBatch(
 	endpointId interface{},
 	timestamp float64,
-	metricList trimessages.MetricList) int {
+	metricList trimessages.MetricList) (numAdded int, ok bool) {
 	return s.addBatch(endpointId, timestamp, metricList)
 }
 
@@ -261,4 +261,9 @@ func (s *Store) RegisterMetrics() error {
 func (s *Store) MarkEndpointInactive(
 	timestamp float64, endpointId interface{}) {
 	s.markEndpointInactive(timestamp, endpointId)
+}
+
+// MarkEndpointActive marks given endpoint as active.
+func (s *Store) MarkEndpointActive(endpointId interface{}) {
+	s.markEndpointActive(endpointId)
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -525,6 +525,14 @@ func TestMachineGoneInactive(t *testing.T) {
 	assertValueEquals(t, 1900.0, result[3].TimeStamp)
 	assertValueEquals(t, 2, result[3].Value)
 	assertValueEquals(t, true, result[3].Active)
+
+	if _, ok := aStore.AddBatch(kEndpoint1, 2000.0, nil); ok {
+		t.Error("Expected AddBatch to fail")
+	}
+	aStore.MarkEndpointActive(kEndpoint1)
+	if _, ok := aStore.AddBatch(kEndpoint1, 2000.0, nil); !ok {
+		t.Error("Expected AddBatch to succeed")
+	}
 }
 
 func TestByNameAndEndpointAndEndpoint(t *testing.T) {
@@ -958,7 +966,11 @@ func addBatch(
 	ts float64,
 	m messages.MetricList,
 	count int) {
-	if out := astore.AddBatch(endpointId, ts, m); out != count {
+	out, ok := astore.AddBatch(endpointId, ts, m)
+	if !ok {
+		t.Errorf("Expected AddBatch to succeed")
+	}
+	if out != count {
 		t.Errorf("Expected %d added, got %d.", count, out)
 	}
 }


### PR DESCRIPTION
This prevents data from latent collections from being added to already
inactive time series.
