### PR TITLE
Introduce store package abstractions for writing to persistent storage.

### DIFF
--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -170,7 +170,7 @@ type pstoreHandlerData struct {
 type pstoreHandlerType struct {
 	writer                  pstore.Writer
 	appList                 *datastructs.ApplicationList
-	iteratorsBeingWritten   []*store.Iterator
+	iteratorsBeingWritten   []*store.OldIterator
 	toBeWritten             []pstore.Record
 	batchSize               int
 	skipped                 int
@@ -194,7 +194,7 @@ func newPStoreHandler(
 	return &pstoreHandlerType{
 		writer:                  w,
 		appList:                 appList,
-		iteratorsBeingWritten:   make([]*store.Iterator, batchSize),
+		iteratorsBeingWritten:   make([]*store.OldIterator, batchSize),
 		toBeWritten:             make([]pstore.Record, batchSize),
 		batchSize:               batchSize,
 		timeSpentWritingDist:    bucketer.NewCumulativeDistribution(),

--- a/datastructs/datastructs_test.go
+++ b/datastructs/datastructs_test.go
@@ -301,7 +301,7 @@ func TestHighPriorityEviction(t *testing.T) {
 	endpointId, aStore := appStatus.EndpointIdByHostAndName(
 		"host3", "AnApp")
 
-	var result []*store.Record
+	var result []store.Record
 	aStore.ByNameAndEndpoint(
 		"/foo",
 		endpointId,

--- a/store/appenders.go
+++ b/store/appenders.go
@@ -1,0 +1,108 @@
+package store
+
+type limitAppenderType struct {
+	limit   int
+	wrapped Appender
+}
+
+func (l *limitAppenderType) Append(r *Record) bool {
+	result := l.wrapped.Append(r)
+	l.limit--
+	if l.limit == 0 {
+		return false
+	}
+	return result
+}
+
+type filterAppenderType struct {
+	filter  Filterer
+	wrapped Appender
+}
+
+func (f *filterAppenderType) Append(r *Record) bool {
+	if f.filter.Filter(r) {
+		return f.wrapped.Append(r)
+	}
+	return true
+}
+
+type recordListType []Record
+
+func (l *recordListType) Append(r *Record) bool {
+	*l = append(*l, *r)
+	return true
+}
+
+type tsAppenderType []float64
+
+func (t *tsAppenderType) Append(r *Record) bool {
+	*t = append(*t, r.TimeStamp)
+	return true
+}
+
+type doneAppenderType struct {
+	Done    bool
+	Wrapped Appender
+}
+
+func (d *doneAppenderType) Append(r *Record) bool {
+	if !d.Wrapped.Append(r) {
+		d.Done = true
+		return false
+	}
+	return true
+}
+
+type mergeWithTimestampsType struct {
+	timestamps    []float64
+	timestampIdx  int
+	wrapped       Appender
+	lastRecord    Record
+	lastRecordSet bool
+}
+
+func newMergeWithTimestamps(
+	timestamps []float64, result Appender) *mergeWithTimestampsType {
+	return &mergeWithTimestampsType{
+		timestamps: timestamps,
+		wrapped:    result}
+}
+
+func (m *mergeWithTimestampsType) Append(r *Record) bool {
+	tsLen := len(m.timestamps)
+	if !m.lastRecordSet {
+		m.lastRecord = *r
+		m.lastRecordSet = true
+		return m.timestampIdx < tsLen
+	}
+	for m.timestampIdx < tsLen {
+		timestamp := m.timestamps[m.timestampIdx]
+		if timestamp >= r.TimeStamp {
+			m.lastRecord = *r
+			return true
+		}
+		m.lastRecord.TimeStamp = timestamp
+		if !m.wrapped.Append(&m.lastRecord) {
+			// Since are appender is bailing early, we don't
+			// want Finalize to do anything
+			m.lastRecordSet = false
+			return false
+		}
+		m.timestampIdx++
+	}
+	return false
+}
+
+func (m *mergeWithTimestampsType) Finalize() {
+	tsLen := len(m.timestamps)
+	if !m.lastRecordSet {
+		return
+	}
+	for m.timestampIdx < tsLen {
+		m.lastRecord.TimeStamp = m.timestamps[m.timestampIdx]
+		if !m.wrapped.Append(&m.lastRecord) {
+			return
+		}
+		m.timestampIdx++
+	}
+}

--- a/store/iterators.go
+++ b/store/iterators.go
@@ -1,0 +1,132 @@
+package store
+
+import (
+	"sort"
+)
+
+type filterIteratorType struct {
+	filter  Filterer
+	wrapped Iterator
+}
+
+func (f *filterIteratorType) Next(r *Record) bool {
+	for f.wrapped.Next(r) {
+		if f.filter.Filter(r) {
+			return true
+		}
+	}
+	return false
+}
+
+type changedNamedIteratorType struct {
+	NamedIterator
+	change Iterator
+}
+
+func (c *changedNamedIteratorType) Next(r *Record) bool {
+	return c.change.Next(r)
+}
+
+// Designed to be immutable
+type namedIteratorDataType struct {
+	startTimeStamps map[int]float64
+	completed       map[*timeSeriesType]float64
+}
+
+type namedIteratorType struct {
+	name                 string
+	timeSeriesCollection *timeSeriesCollectionType
+	// startTimeStamps does not change during this instance's lifetime
+	startTimeStamps   map[int]float64
+	timestamps        map[int][]float64
+	completed         map[*timeSeriesType]float64
+	timeSeries        []*timeSeriesType
+	records           []Record
+	recordIdx         int
+	currentTimeSeries *timeSeriesType
+}
+
+func (n *namedIteratorType) moreRecords() bool {
+	if len(n.timeSeries) == 0 {
+		return false
+	}
+	n.currentTimeSeries = n.timeSeries[0]
+	n.timeSeries = n.timeSeries[1:]
+	ourTimestamps := n.timestamps[n.currentTimeSeries.GroupId()]
+	lastWrittenTimestamp := n.completed[n.currentTimeSeries]
+	index := sort.Search(
+		len(ourTimestamps),
+		func(x int) bool {
+			return ourTimestamps[x] > lastWrittenTimestamp
+		})
+	n.records = n.records[:0]
+	n.currentTimeSeries.FetchForwardWithTimeStamps(
+		n.timeSeriesCollection.applicationId,
+		ourTimestamps[index:],
+		AppendTo(&n.records))
+	return true
+}
+
+func copyCompleted(
+	original map[*timeSeriesType]float64) map[*timeSeriesType]float64 {
+	result := make(map[*timeSeriesType]float64, len(original))
+	for k, v := range original {
+		result[k] = v
+	}
+	return result
+}
+
+func (n *namedIteratorType) nextStartTimeStamps() map[int]float64 {
+	result := make(map[int]float64, len(n.startTimeStamps))
+	for k, v := range n.startTimeStamps {
+		result[k] = v
+	}
+	for groupId, tss := range n.timestamps {
+		length := len(tss)
+		if length > 0 {
+			result[groupId] = tss[length-1]
+		}
+	}
+	return result
+}
+
+func (n *namedIteratorType) snapshot() *namedIteratorDataType {
+	if !n.hasNext() {
+		return &namedIteratorDataType{
+			startTimeStamps: n.nextStartTimeStamps(),
+		}
+	}
+	return &namedIteratorDataType{
+		startTimeStamps: n.startTimeStamps,
+		completed:       copyCompleted(n.completed),
+	}
+}
+
+func (n *namedIteratorType) Name() string {
+	return n.name
+}
+
+func (n *namedIteratorType) Commit() {
+	n.timeSeriesCollection.saveProgress(n.name, n.snapshot())
+}
+
+func (n *namedIteratorType) hasNext() bool {
+	for n.recordIdx == len(n.records) {
+		if !n.moreRecords() {
+			return false
+		}
+		n.recordIdx = 0
+	}
+	return true
+}
+
+func (n *namedIteratorType) Next(r *Record) bool {
+	if !n.hasNext() {
+		return false
+	}
+	*r = n.records[n.recordIdx]
+	n.recordIdx++
+	// Mark current progress
+	n.completed[n.currentTimeSeries] = r.TimeStamp
+	return true
+}


### PR DESCRIPTION
In this commit, we introduce Iterators and develop Appenders.
All Iterator implementations go in iterators.go; all Appender
implementations go in appenders.go to keep store.go smaller.

Also in this commit, we introduce the timestampSeriesType to store
series of just timestamps with no values. Since both timeSeriesType
and timeStampSeriesType are both sequences of pages that store items,
they share common functionality. Therefore we factor out that common
functionality into pageSeriesType. Both timeSeriesType and
timeStampSeriesType have an anonymous pageSeriesType field.

Pages of timestamps and pages of values also share common functionality.
We introduce the basicPageType interface to provide a uniform way to
search a page by timestamp, iterate over a page, clear a page, and get
the number of items in a page.

We add a map of groupId to timeStampSeriesType inside
timeSeriesCollectionType so that we can keep track of all the timestamps
for each endpoint.

To facilitate writing every metric for every timestamp to persistent
storage, we add additional methods to TimeSeriesCollectionType like
FetchForward and FetchForwardWithTimeStamps designed for fetching values
to write to persistent storage.

Finally we introduce the NamedIterator abstraction to encapsulate away
the details of fetching the data to write to persistent storage and
keeping track of what has been written out and what has not. Clients get
a NamedIterator for an endpoint and iterate over it to write the values
out to persistent storage. If writing to persistent storage is
successful, the client can commit its progress.
