### PR TITLE
Scotty to collect metrics from different types of sources.

### DIFF
--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Symantec/scotty/apps/scotty/splash"
 	"github.com/Symantec/scotty/datastructs"
 	"github.com/Symantec/scotty/messages"
+	"github.com/Symantec/scotty/metrics"
 	"github.com/Symantec/scotty/pstore"
 	"github.com/Symantec/scotty/pstore/kafka"
 	"github.com/Symantec/scotty/store"
@@ -405,12 +406,12 @@ func (l *loggerType) LogError(e *collector.Endpoint, err error, state *collector
 }
 
 func (l *loggerType) LogResponse(
-	e *collector.Endpoint, metrics trimessages.MetricList, state *collector.State) {
+	e *collector.Endpoint, list metrics.List, state *collector.State) {
 	ts := trimessages.TimeToFloat(state.Timestamp())
 	added, ok := l.Store.AddBatch(
 		e,
 		ts,
-		metrics)
+		list)
 	if ok {
 		l.AppStats.LogChangedMetricCount(e, added)
 		l.ChangedMetricsDist.Add(float64(added))

--- a/datastructs/datastructs_test.go
+++ b/datastructs/datastructs_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/Symantec/scotty"
+	"github.com/Symantec/scotty/metrics"
 	"github.com/Symantec/scotty/store"
-	"github.com/Symantec/tricorder/go/tricorder/messages"
 	"github.com/Symantec/tricorder/go/tricorder/types"
 	"github.com/Symantec/tricorder/go/tricorder/units"
 	"math"
@@ -102,7 +102,7 @@ func (a *activeInactiveListType) Visit(
 }
 
 func activateEndpoints(endpoints []*scotty.Endpoint, s *store.Store) {
-	aMetric := [4]*messages.Metric{
+	aMetric := metrics.SimpleList{
 		{
 			Path:        "/foo/first",
 			Description: "A description",
@@ -242,8 +242,10 @@ func TestMarkHostsActiveExclusively(t *testing.T) {
 	endpointId, aStore = appStatus.EndpointIdByHostAndName(
 		"host3", "AnApp")
 
+	var noMetrics metrics.SimpleList
+
 	// Trying to add to active endpoint should succeed
-	if _, ok := aStore.AddBatch(endpointId, 9999.0, nil); !ok {
+	if _, ok := aStore.AddBatch(endpointId, 9999.0, noMetrics); !ok {
 		t.Error("Adding to active endpoint should succeed.")
 	}
 
@@ -343,7 +345,7 @@ func TestHighPriorityEviction(t *testing.T) {
 }
 
 func addDataForHighPriorityEvictionTest(appStatus *ApplicationStatuses) {
-	aMetric := [1]*messages.Metric{
+	aMetric := metrics.SimpleList{
 		{
 			Path:        "/foo",
 			Description: "A description",

--- a/metrics/api.go
+++ b/metrics/api.go
@@ -1,0 +1,53 @@
+// Package metrics provides a view of metrics that is independent of source.
+package metrics
+
+import (
+	"github.com/Symantec/tricorder/go/tricorder/types"
+	"github.com/Symantec/tricorder/go/tricorder/units"
+	"time"
+)
+
+// Value represents a single metric value.
+type Value struct {
+	// Required. The name of the metric. For tricorder metrics, this is
+	// the metric path.
+	Path string
+	// Optional. The description of the metric.
+	Description string
+	// Required. The unit of the metric. Will be units.None if unknown.
+	Unit units.Unit
+	// Required. The kind of the metric.
+	Kind types.Type
+	// Optional. The number of bits.
+	Bits int
+	// Required. Value is the value of the metric. The type stored in
+	// value depends on Kind according to the tricorder documentation.
+	Value interface{}
+	// Optional. The timestamp of the value.
+	TimeStamp time.Time
+	// Optional. The timestamp group ID. Required if TimeStamp is provided.
+	// If a.GroupId == b.GroupId then a.TimeStamp == b.TimeStamp, but
+	// the converse does not have to be true. Furthermore, GroupId must
+	// remain the same for all values of a given metric. However,
+	// multiple metrics can share the same group ID.
+	GroupId int
+}
+
+// List represents a list of metrics from an endpoint.
+type List interface {
+	// Len returns the number of metrics.
+	Len() int
+	// Index stores the ith metric at value
+	Index(i int, value *Value)
+}
+
+// SimpleList lets a slice of Value instances be a List.
+type SimpleList []Value
+
+func (s SimpleList) Len() int {
+	return len(s)
+}
+
+func (s SimpleList) Index(i int, value *Value) {
+	*value = s[i]
+}

--- a/sources/api.go
+++ b/sources/api.go
@@ -1,0 +1,19 @@
+// Package sources provides the interfaces for metric sources.
+package sources
+
+import (
+	"github.com/Symantec/scotty/metrics"
+)
+
+// Connector connects to a particular type of source.
+// Connector implementations must be safe to use with multiple goroutines.
+type Connector interface {
+	Connect(host string, port int) (Poller, error)
+	Name() string
+}
+
+// Poller polls metrics from a particular source
+type Poller interface {
+	Poll() (metrics.List, error)
+	Close() error
+}

--- a/sources/trisource/api.go
+++ b/sources/trisource/api.go
@@ -1,0 +1,10 @@
+// Package trisource connects to sources using tricorder.
+package trisource
+
+import (
+	"github.com/Symantec/scotty/sources"
+)
+
+func GetConnector() sources.Connector {
+	return kConnector
+}

--- a/sources/trisource/trisource.go
+++ b/sources/trisource/trisource.go
@@ -1,0 +1,82 @@
+package trisource
+
+import (
+	"fmt"
+	"github.com/Symantec/scotty/metrics"
+	"github.com/Symantec/scotty/sources"
+	"github.com/Symantec/tricorder/go/tricorder/messages"
+	"github.com/Symantec/tricorder/go/tricorder/types"
+	"net/rpc"
+	"time"
+)
+
+type connectorType int
+
+var (
+	kConnector = connectorType(0)
+)
+
+func (c connectorType) Connect(host string, port int) (sources.Poller, error) {
+	conn, err := rpc.DialHTTP(
+		"tcp",
+		fmt.Sprintf("%s:%d", host, port))
+	if err != nil {
+		return nil, err
+	}
+	return pollerType{conn}, nil
+}
+
+func (c connectorType) Name() string {
+	return "tricorder"
+}
+
+type pollerType struct {
+	*rpc.Client
+}
+
+func (p pollerType) Poll() (result metrics.List, err error) {
+	var values messages.MetricList
+	err = p.Call("MetricsServer.ListMetrics", "", &values)
+	if err != nil {
+		return
+	}
+	for i := range values {
+		values[i].Kind = fixupKind(values[i].Kind)
+	}
+	return listType(values), nil
+}
+
+type listType messages.MetricList
+
+func (l listType) Len() int {
+	return len(l)
+}
+
+func (l listType) Index(i int, result *metrics.Value) {
+	result.Path = l[i].Path
+	result.Description = l[i].Description
+	result.Unit = l[i].Unit
+	result.Kind = l[i].Kind
+	result.Bits = l[i].Bits
+	result.Value = l[i].Value
+	if l[i].TimeStamp == nil {
+		result.TimeStamp = time.Time{}
+	} else {
+		result.TimeStamp = l[i].TimeStamp.(time.Time)
+	}
+	result.GroupId = l[i].GroupId
+}
+
+// TODO: Delete once all apps link with new tricorder
+func fixupKind(k types.Type) types.Type {
+	switch k {
+	case "int":
+		return types.Int64
+	case "uint":
+		return types.Uint64
+	case "float":
+		return types.Float64
+	default:
+		return k
+	}
+}

--- a/store/api.go
+++ b/store/api.go
@@ -2,7 +2,7 @@
 package store
 
 import (
-	trimessages "github.com/Symantec/tricorder/go/tricorder/messages"
+	"github.com/Symantec/scotty/metrics"
 	"github.com/Symantec/tricorder/go/tricorder/types"
 	"github.com/Symantec/tricorder/go/tricorder/units"
 )
@@ -274,7 +274,7 @@ func (s *Store) RegisterEndpoint(endpointId interface{}) {
 func (s *Store) AddBatch(
 	endpointId interface{},
 	timestamp float64,
-	metricList trimessages.MetricList) (numAdded int, ok bool) {
+	metricList metrics.List) (numAdded int, ok bool) {
 	return s.addBatch(endpointId, timestamp, metricList)
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -1,8 +1,8 @@
 package store
 
 import (
+	"github.com/Symantec/scotty/metrics"
 	"github.com/Symantec/tricorder/go/tricorder"
-	"github.com/Symantec/tricorder/go/tricorder/messages"
 	"github.com/Symantec/tricorder/go/tricorder/units"
 	"time"
 )
@@ -45,7 +45,7 @@ func (s *Store) shallowCopy() *Store {
 func (s *Store) addBatch(
 	endpointId interface{},
 	timestamp float64,
-	mlist messages.MetricList) (int, bool) {
+	mlist metrics.List) (int, bool) {
 	return s.byApplication[endpointId].AddBatch(
 		timestamp, mlist, s.supplier)
 }


### PR DESCRIPTION
This is phase I of getting scotty to collect metrics from things other than tricorder client.
This phase introduces the abstractions necessary to support multiple types of clients.
