### PR TITLE
Ensure that iteration skips timestamps with no matching values.

### DIFF
--- a/store/api.go
+++ b/store/api.go
@@ -338,7 +338,9 @@ func (s *Store) ByEndpoint(
 // If maxFrames = 0, the returned iterator will make best effort to iterate
 // over all the metric values in the endpoint. A positive maxFrames hints to
 // the returned iterator that it should iterate over at most maxFrames values
-// per metric. Caller must commit progress and create a new iterator with the
+// per metric. Returned iterator is free to iterate over fewer than maxFrames
+// values for a metric even if that metric has additional values.
+// Caller must commit progress and create a new iterator with the
 // same name for the same endpoint to see the rest of the values.
 func (s *Store) NamedIteratorForEndpoint(
 	name string,

--- a/store/appenders.go
+++ b/store/appenders.go
@@ -63,6 +63,23 @@ type mergeWithTimestampsType struct {
 	lastRecordSet bool
 }
 
+// newMergeWithTimestamps creates an appender that accepts unique timestamped
+// values, merges them with the timestamps in timestamps, and emits them to
+// result.
+//
+// This appender will emit each value it accepts 0 or more times to result
+// depending on how many timestamps in the timestamps array fall on it or
+// immediately after it. For example, if this appender accepts value A
+// with timestamp 1000 and value B with timestamp 1004 and value C with
+// timestamp 1007 and the timestamp array contains:
+// ..., 1000, 1002, 1003, 1008,... then this appender will emit:
+// ...; A, 1000; A, 1002; A, 1003; C, 1008; ... to result
+// Note that no B is emitted to result as there is no timestamp that falls
+// on 1004 or immediately after 1004 but not before C's timestamp of 1007.
+//
+// The timestamps array must be sorted in ascending order and the returned
+// appender must accept value-timestamp records in ascending order by
+// timestamp.
 func newMergeWithTimestamps(
 	timestamps []float64, result Appender) *mergeWithTimestampsType {
 	return &mergeWithTimestampsType{
@@ -72,18 +89,39 @@ func newMergeWithTimestamps(
 
 func (m *mergeWithTimestampsType) Append(r *Record) bool {
 	tsLen := len(m.timestamps)
+
+	// We hit this block when we accept the very first timestamp-value
+	// record. We remember that we will emit for this first value
+	// but we don't emit anything just yet.
 	if !m.lastRecordSet {
 		m.lastRecord = *r
 		m.lastRecordSet = true
-		return m.timestampIdx < tsLen
+		// Advance through timestamps until we get a timestamp that
+		// falls on or after the value we just accepted.
+		for m.timestampIdx < tsLen {
+			if m.timestamps[m.timestampIdx] >= r.TimeStamp {
+				return true
+			}
+			m.timestampIdx++
+		}
+		// If we reached end of timestamp array, let caller know we
+		// are done accepting values.
+		return false
 	}
+	// We always start here if we are accepting our second, third, fourth
+	// etc. value timestamp pair. We emit to wrapped appender for each
+	// timestamp using the previous value until the timestamp falls on
+	// or after the timestamp of the value we just accepted.
 	for m.timestampIdx < tsLen {
 		timestamp := m.timestamps[m.timestampIdx]
+
+		// We are done emitting for the previous value.
 		if timestamp >= r.TimeStamp {
 			m.lastRecord = *r
 			return true
 		}
 		m.lastRecord.TimeStamp = timestamp
+		// Emit
 		if !m.wrapped.Append(&m.lastRecord) {
 			// Since our appender is bailing early, we don't
 			// want Finalize to do anything
@@ -92,9 +130,13 @@ func (m *mergeWithTimestampsType) Append(r *Record) bool {
 		}
 		m.timestampIdx++
 	}
+	// If we reached end ot timestamps, tell caller we are done accepting
+	// values.
 	return false
 }
 
+// Caller must always call Finalize when done with this instance.
+// Finalize may emit additional items to the underlying appender.
 func (m *mergeWithTimestampsType) Finalize() {
 	tsLen := len(m.timestamps)
 	if !m.lastRecordSet {


### PR DESCRIPTION
This fix ensures that if timestamps go back earlier than the values (this can happen since timestamp pages are evicted separately), that these earliest timestamps are skipped rather than being paired with the first available later value. Pairing timestamps to values that come later causes scotty to write timestamp value pairs to LMM that never existed in scotty at any time.

Doing this caused the test that ensures that LMM writing will skip values that fall out of scotty to catch up to fail. I rewrote that test to be less fragile going forward.
