### PR TITLE
Names, concurrency, and batch size to each persistent store.

### DIFF
--- a/pstore/config/api.go
+++ b/pstore/config/api.go
@@ -59,19 +59,14 @@ type ConsumerBuilderFactoryList interface {
 	// Create a Consumer builder from item at given index.
 	NewConsumerBuilderByIndex(idx int) (
 		*pstore.ConsumerWithMetricsBuilder, error)
+	// Returns the name of the item at the given index.
+	NameAt(idx int) string
 }
 
 // CreateConsumerBuilders creates consumer builders from c.
 func CreateConsumerBuilders(c ConsumerBuilderFactoryList) (
-	list pstore.ConsumerWithMetricsBuilderList, err error) {
-	result := make(pstore.ConsumerWithMetricsBuilderList, c.Len())
-	for i := range result {
-		if result[i], err = c.NewConsumerBuilderByIndex(i); err != nil {
-			return
-		}
-	}
-	list = result
-	return
+	list []*pstore.ConsumerWithMetricsBuilder, err error) {
+	return createConsumerBuilders(c)
 }
 
 // Reset resets all the configs.
@@ -83,7 +78,8 @@ func Reset(configs ...Config) {
 
 // Decorator creates a decorated writer.
 type Decorator struct {
-	// Maximum reocrds to write per minute. 0 or negative means no limit.
+	// Maximum reocrds to write per minute. Optional.
+	// 0 or negative means no limit.
 	RecordsPerMinute int `yaml:"recordsPerMinute"`
 	// Metrics whose name matches DebugMetricRegex AND whose host matches
 	// DebugHostRegex are written to the debug file. Empty values in
@@ -92,7 +88,8 @@ type Decorator struct {
 	// matches.
 	DebugMetricRegex string `yaml:"debugMetricRegex"`
 	DebugHostRegex   string `yaml:"debugHostRegex"`
-	// The full path of the debug file. If empty, debug goes to stdout.
+	// The full path of the debug file. Optional.
+	// If empty, debug goes to stdout.
 	DebugFilePath string `yaml:"debugFilePath"`
 }
 
@@ -108,6 +105,14 @@ func (d *Decorator) Reset() {
 
 // ConsumerConfig creates a consumer builder
 type ConsumerConfig struct {
+	// The name of the consumer. Required.
+	Name string `yaml:"name"`
+	// The number of goroutines doing writing. Optional.
+	// A zero or negative value means 1.
+	Concurrency int `yaml:"concurrency"`
+	// The number of values written each time. Optional.
+	// A zero or negative value means 1000.
+	BatchSize int `yaml:"batchSize"`
 }
 
 // NewConsumerBuilder creates a new consumer builder using the given

--- a/pstore/influx/api.go
+++ b/pstore/influx/api.go
@@ -17,7 +17,7 @@ func FromFile(filename string) (result pstore.LimitedRecordWriter, err error) {
 
 // ConsumerBuildersFromFile creates consumer builders from a configuration file.
 func ConsumerBuildersFromFile(filename string) (
-	result pstore.ConsumerWithMetricsBuilderList, err error) {
+	result []*pstore.ConsumerWithMetricsBuilder, err error) {
 	var c ConfigList
 	if err = config.ReadFromFile(filename, &c); err != nil {
 		return
@@ -78,6 +78,10 @@ func (c ConfigList) Len() int {
 func (c ConfigList) NewConsumerBuilderByIndex(i int) (
 	*pstore.ConsumerWithMetricsBuilder, error) {
 	return c[i].NewConsumerBuilder()
+}
+
+func (c ConfigList) NameAt(i int) string {
+	return c[i].Consumer.Name
 }
 
 func (c *ConfigList) Reset() {

--- a/pstore/kafka/api.go
+++ b/pstore/kafka/api.go
@@ -28,7 +28,7 @@ func FromFile(filename string) (result pstore.LimitedRecordWriter, err error) {
 
 // ConsumerBuildersFromFile creates consumer builders from a configuration file.
 func ConsumerBuildersFromFile(filename string) (
-	result pstore.ConsumerWithMetricsBuilderList, err error) {
+	result []*pstore.ConsumerWithMetricsBuilder, err error) {
 	var c ConfigList
 	if err = config.ReadFromFile(filename, &c); err != nil {
 		return
@@ -104,6 +104,10 @@ func (c ConfigList) Len() int {
 func (c ConfigList) NewConsumerBuilderByIndex(i int) (
 	*pstore.ConsumerWithMetricsBuilder, error) {
 	return c[i].NewConsumerBuilder()
+}
+
+func (c ConfigList) NameAt(i int) string {
+	return c[i].Consumer.Name
 }
 
 func (c *ConfigList) Reset() {


### PR DESCRIPTION
In this PR, 
1. Allow the config file to assign each persistent store a meaningful name. 
2. allow the config file to specify a separate concurrency level and batch size for each persistent store.
