### PR TITLE
Show rollup interval on metrics page for writers.

### DIFF
--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -317,6 +317,13 @@ func (p *pstoreHandlerType) RegisterMetrics() (err error) {
 		"This many records written each time"); err != nil {
 		return
 	}
+	if err = tricorder.RegisterMetric(
+		fmt.Sprintf("writer/%s/rollUpSpan", p.Name()),
+		&attributes.RollUpSpan,
+		units.None,
+		"Time period length for rolled up values. 0 means no roll up."); err != nil {
+		return
+	}
 	if err = tricorder.RegisterMetricInGroup(
 		fmt.Sprintf("writer/%s/valuesWritten", p.Name()),
 		&data.ValuesWritten,

--- a/pstore/config/api.go
+++ b/pstore/config/api.go
@@ -114,7 +114,9 @@ type ConsumerConfig struct {
 	Concurrency int `yaml:"concurrency"`
 	// The number of values written each time. Optional.
 	// A zero or negative value means 1000.
-	BatchSize  int           `yaml:"batchSize"`
+	BatchSize int `yaml:"batchSize"`
+	// The length of time for rolling up values when writing. Optional.
+	// Zero means write every value and do no rollup.
 	RollUpSpan time.Duration `yaml:"rollUpSpan"`
 }
 


### PR DESCRIPTION
Add documentation to rollup field for config files.
