### PR TITLE
Expose all pstore configuration elements in consumer builder

### DIFF
--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -208,7 +208,6 @@ func (t *totalCountType) Update(
 type pstoreHandlerType struct {
 	consumer            *pstore.ConsumerWithMetrics
 	appList             *datastructs.ApplicationList
-	memoryManager       *memoryManagerType
 	startTime           time.Time
 	totalTimeSpentDist  *tricorder.CumulativeDistribution
 	perMetricWriteTimes *tricorder.CumulativeDistribution
@@ -216,15 +215,13 @@ type pstoreHandlerType struct {
 
 func newPStoreHandler(
 	appList *datastructs.ApplicationList,
-	consumer *pstore.ConsumerWithMetricsBuilder,
-	memoryManager *memoryManagerType) *pstoreHandlerType {
+	consumer *pstore.ConsumerWithMetricsBuilder) *pstoreHandlerType {
 	bucketer := tricorder.NewGeometricBucketer(1e-4, 1000.0)
 	perMetricWriteTimes := bucketer.NewCumulativeDistribution()
 	consumer.SetPerMetricWriteTimeDist(perMetricWriteTimes)
 	return &pstoreHandlerType{
 		consumer:            consumer.Build(),
 		appList:             appList,
-		memoryManager:       memoryManager,
 		totalTimeSpentDist:  bucketer.NewCumulativeDistribution(),
 		perMetricWriteTimes: perMetricWriteTimes,
 	}
@@ -252,9 +249,6 @@ func (p *pstoreHandlerType) Visit(
 	appName := p.appList.ByPort(port).Name()
 	iterator := p.namedIterator(theStore, endpointId)
 	p.consumer.Write(iterator, hostName, appName)
-	if p.memoryManager != nil {
-		p.memoryManager.Check()
-	}
 	return nil
 }
 
@@ -662,16 +656,23 @@ func (h byEndpointHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	encodeJson(w, data, r.Form.Get("format") == "text")
 }
 
-func newPStoreConsumers() (
+func newPStoreConsumers(memoryManager *memoryManagerType) (
 	result []*pstore.ConsumerWithMetricsBuilder, err error) {
 	if *fKafkaConfigFile != "" {
-		return kafka.ConsumerBuildersFromFile(*fKafkaConfigFile)
+		result, err = kafka.ConsumerBuildersFromFile(
+			*fKafkaConfigFile)
 	}
 	if *fInfluxConfigFile != "" {
-		return influx.ConsumerBuildersFromFile(*fInfluxConfigFile)
+		result, err = influx.ConsumerBuildersFromFile(
+			*fInfluxConfigFile)
 	}
 	if *fTsdbConfigFile != "" {
-		return tsdb.ConsumerBuildersFromFile(*fTsdbConfigFile)
+		result, err = tsdb.ConsumerBuildersFromFile(*fTsdbConfigFile)
+	}
+	// Add hook to check memory after each write
+	for i := range result {
+		result[i].AddWriterHook(
+			writerHookType{wrapped: memoryManager})
 	}
 	return
 }
@@ -803,6 +804,15 @@ func (m *memoryManagerType) loop() {
 	}
 }
 
+type writerHookType struct {
+	wrapped *memoryManagerType
+}
+
+func (w writerHookType) WriteCalled(
+	unusedRecords []pstore.Record, unusedError error) {
+	w.wrapped.Check()
+}
+
 func createApplicationStats(
 	appList *datastructs.ApplicationList,
 	logger *log.Logger,
@@ -929,14 +939,12 @@ func startCollector(
 func startPStoreLoops(
 	stats *datastructs.ApplicationStatuses,
 	consumerBuilders []*pstore.ConsumerWithMetricsBuilder,
-	memoryManager *memoryManagerType,
 	logger *log.Logger) []*totalCountType {
 	result := make([]*totalCountType, len(consumerBuilders))
 	for i := range result {
 		pstoreHandler := newPStoreHandler(
 			stats.ApplicationList(),
-			consumerBuilders[i],
-			memoryManager)
+			consumerBuilders[i])
 		result[i] = pstoreHandler.TotalCount()
 		var attributes pstore.ConsumerAttributes
 		pstoreHandler.Attributes(&attributes)
@@ -1007,13 +1015,13 @@ func main() {
 	logger := log.New(circularBuffer, "", log.LstdFlags)
 	handleSignals(logger)
 	// Read configs early so that we will fail fast.
-	consumerBuilders, err := newPStoreConsumers()
+	memoryManager := createMemoryManager(logger)
+	consumerBuilders, err := newPStoreConsumers(memoryManager)
 	if err != nil {
 		log.Println(err)
 		logger.Println(err)
 	}
 	appList := createApplicationList()
-	memoryManager := createMemoryManager(logger)
 	applicationStats := createApplicationStats(
 		appList, logger, memoryManager)
 	connectionErrors := newConnectionErrorsType()
@@ -1024,7 +1032,6 @@ func main() {
 		totalCounts := startPStoreLoops(
 			applicationStats,
 			consumerBuilders,
-			memoryManager,
 			logger)
 		startCollector(
 			applicationStats,

--- a/pstore/api.go
+++ b/pstore/api.go
@@ -82,14 +82,6 @@ type ThrottledLimitedRecordWriter interface {
 	RecordsPerSecond() int
 }
 
-// NewThrottledLimitedRecordWriter creates a new ThrottledLimitedRecordWriter.
-// recordsPerSecond <= 0 means unlimited rate.
-func NewThrottledLimitedRecordWriter(
-	w LimitedRecordWriter,
-	recordsPerSecond int) ThrottledLimitedRecordWriter {
-	return newThrottledLimitedRecordWriter(w, recordsPerSecond)
-}
-
 // RecordWriterMetrics represents writing metrics
 type RecordWriterMetrics struct {
 	ValuesWritten    uint64
@@ -317,29 +309,56 @@ func (c *ConsumerWithMetrics) Flush() {
 	c.consumer.Flush()
 }
 
+// Instances that want to know when a batch of records are written to
+// persistent store implement this interface.
+type RecordWriterHook interface {
+	// WriteCalled is called just after a write or attempted write to
+	// pstore. records are the records written; err is the resulting
+	// error if any. Implementations must not modify the records array.
+	WriteCalled(records []Record, result error)
+}
+
 // ConsumerWithMetricsBuilder builds a ConsumerWithMetrics instance.
 // Each instance is good for building one and only one ConsumerWithMetrics
 // instance.
 // These instances are NOT safe to use with multiple goroutines.
 type ConsumerWithMetricsBuilder struct {
-	c **ConsumerWithMetrics
+	c     *ConsumerWithMetrics
+	hooks []RecordWriterHook
 }
 
 // NewConsumerWithMetricsBuilder creates a new instance that will
 // build a consumer that uses w to write values out.
 func NewConsumerWithMetricsBuilder(
-	w ThrottledLimitedRecordWriter) *ConsumerWithMetricsBuilder {
+	w LimitedRecordWriter) *ConsumerWithMetricsBuilder {
 	return newConsumerWithMetricsBuilder(w)
+}
+
+// AddWriterHook adds a hook for writes. hook must be non-nil.
+func (b *ConsumerWithMetricsBuilder) AddWriterHook(hook RecordWriterHook) {
+	if hook == nil {
+		panic("nil RecordWriterHook")
+	}
+	b.hooks = append(b.hooks, hook)
+}
+
+// SetRecordsPerSecond throttles writes. Default is 0 which means no
+// throttling. SetRecordsPerSecond panics if recordsPerSecond is negative.
+func (b *ConsumerWithMetricsBuilder) SetRecordsPerSecond(
+	recordsPerSecond int) {
+	if recordsPerSecond < 0 {
+		panic("recordsPerSecond must be non negative")
+	}
+	b.c.attributes.RecordsPerSecond = recordsPerSecond
 }
 
 // SetBufferSize sets how many values the consumer will buffer before
 // writing them out. The default is 1000. SetBufferSize panics if size < 1.
-
 func (b *ConsumerWithMetricsBuilder) SetBufferSize(size int) {
 	if size < 1 {
 		panic("positive, non-zero size required.")
 	}
-	(*b.c).attributes.BatchSize = size
+	b.c.attributes.BatchSize = size
 }
 
 // SetConcurrency sets how many goroutines will write to the underlying
@@ -348,7 +367,7 @@ func (b *ConsumerWithMetricsBuilder) SetConcurrency(concurrency int) {
 	if concurrency < 1 {
 		panic("positive, non-zero concurrency required.")
 	}
-	(*b.c).attributes.Concurrency = concurrency
+	b.c.attributes.Concurrency = concurrency
 }
 
 // SetRollUpSpan sets the length of time periods for rolled up values
@@ -358,19 +377,19 @@ func (b *ConsumerWithMetricsBuilder) SetRollUpSpan(dur time.Duration) {
 	if dur < 0 {
 		panic("Non-negative duration required.")
 	}
-	(*b.c).attributes.RollUpSpan = dur
+	b.c.attributes.RollUpSpan = dur
 }
 
 // SetName sets the name of the consumer. Default is the empty string.
 func (b *ConsumerWithMetricsBuilder) SetName(name string) {
-	(*b.c).name = name
+	b.c.name = name
 }
 
 // SetPerMetricWriteTimeDist sets the distribution that the consumer will
 // use to record write times. The default is not to record write times.
 func (b *ConsumerWithMetricsBuilder) SetPerMetricWriteTimeDist(
 	d *tricorder.CumulativeDistribution) {
-	(*b.c).metricsStore.w.PerMetricWriteTimes = d
+	b.c.metricsStore.w.PerMetricWriteTimes = d
 }
 
 // SetPerMetricBatchSizeDist sets the distribution that the consumer will
@@ -378,7 +397,7 @@ func (b *ConsumerWithMetricsBuilder) SetPerMetricWriteTimeDist(
 // The default is not to record batch sizes.
 func (b *ConsumerWithMetricsBuilder) SetPerMetricBatchSizeDist(
 	d *tricorder.CumulativeDistribution) {
-	(*b.c).metricsStore.w.BatchSizes = d
+	b.c.metricsStore.w.BatchSizes = d
 }
 
 // Build builds the ConsumerWithMetrics instance and destroys this builder.

--- a/pstore/config/api.go
+++ b/pstore/config/api.go
@@ -94,13 +94,6 @@ type Decorator struct {
 	DebugFilePath string `yaml:"debugFilePath"`
 }
 
-// NewThrottledWriter creates a new, decorated writer using the given
-// WriterFactory
-func (d *Decorator) NewThrottledWriter(wf WriterFactory) (
-	pstore.ThrottledLimitedRecordWriter, error) {
-	return d.newThrottledWriter(wf)
-}
-
 func (d *Decorator) Reset() {
 	*d = Decorator{}
 }
@@ -123,7 +116,7 @@ type ConsumerConfig struct {
 func (c *ConsumerConfig) NewConsumerBuilder(
 	wf WriterFactory, d *Decorator) (
 	*pstore.ConsumerWithMetricsBuilder, error) {
-	return c.newConsumerBuilder(wf, d)
+	return c.newConsumerBuilder(wf, *d)
 }
 
 func (c *ConsumerConfig) Reset() {

--- a/pstore/config/config.go
+++ b/pstore/config/config.go
@@ -78,62 +78,48 @@ func (f *filterWriter) Write(records []pstore.Record) error {
 	return f.Wrapped.Write(filtered)
 }
 
-type dualWriter struct {
-	pstore.ThrottledLimitedRecordWriter
-	Extra pstore.RecordWriter
+type hookWriter struct {
+	wrapped pstore.RecordWriter
 }
 
-func (d *dualWriter) Write(records []pstore.Record) error {
-	result := d.ThrottledLimitedRecordWriter.Write(records)
-	if result == nil {
-		d.Extra.Write(records)
+func (h *hookWriter) WriteCalled(records []pstore.Record, err error) {
+	if err == nil {
+		h.wrapped.Write(records)
 	}
-	return result
 }
 
-func (d Decorator) newThrottledWriter(wf WriterFactory) (
-	result pstore.ThrottledLimitedRecordWriter, err error) {
-	writer, err := wf.NewWriter()
+func newWriterHook(debugMetricRegex, debugHostRegex, debugFilePath string) (
+	result pstore.RecordWriterHook, err error) {
+	var fakeWriter pstore.RecordWriter
+	fakeWriter, err = newFakeWriterToPath(debugFilePath)
 	if err != nil {
 		return
 	}
-	twriter := pstore.NewThrottledLimitedRecordWriter(
-		writer, d.RecordsPerSecond)
-	if d.DebugMetricRegex != "" || d.DebugHostRegex != "" {
-		var fakeWriter pstore.RecordWriter
-		fakeWriter, err = newFakeWriterToPath(d.DebugFilePath)
-		if err != nil {
-			return
-		}
-		var metricRegex, hostRegex *regexp.Regexp
-		if d.DebugMetricRegex != "" {
-			metricRegex = regexp.MustCompile(d.DebugMetricRegex)
-		}
-		if d.DebugHostRegex != "" {
-			hostRegex = regexp.MustCompile(d.DebugHostRegex)
-		}
-		afilter := func(r *pstore.Record) bool {
-			if metricRegex != nil && !metricRegex.MatchString(r.Path) {
-				return false
-			}
-			if hostRegex != nil && !hostRegex.MatchString(r.HostName) {
-				return false
-			}
-			return true
-		}
-		filterWriter := &filterWriter{
-			Wrapped: fakeWriter,
-			Filter:  afilter,
-		}
-		result = &dualWriter{twriter, filterWriter}
-	} else {
-		result = twriter
+	var metricRegex, hostRegex *regexp.Regexp
+	if debugMetricRegex != "" {
+		metricRegex = regexp.MustCompile(debugMetricRegex)
 	}
-	return
+	if debugHostRegex != "" {
+		hostRegex = regexp.MustCompile(debugHostRegex)
+	}
+	afilter := func(r *pstore.Record) bool {
+		if metricRegex != nil && !metricRegex.MatchString(r.Path) {
+			return false
+		}
+		if hostRegex != nil && !hostRegex.MatchString(r.HostName) {
+			return false
+		}
+		return true
+	}
+	filterWriter := &filterWriter{
+		Wrapped: fakeWriter,
+		Filter:  afilter,
+	}
+	return &hookWriter{wrapped: filterWriter}, nil
 }
 
 func (c ConsumerConfig) newConsumerBuilder(
-	wf WriterFactory, d *Decorator) (
+	wf WriterFactory, d Decorator) (
 	result *pstore.ConsumerWithMetricsBuilder, err error) {
 	if c.Name == "" {
 		return nil, errors.New("Name field is required.")
@@ -147,16 +133,28 @@ func (c ConsumerConfig) newConsumerBuilder(
 	if c.RollUpSpan < 0 {
 		c.RollUpSpan = 0
 	}
-	writer, err := d.NewThrottledWriter(wf)
+	writer, err := wf.NewWriter()
 	if err != nil {
 		return
 	}
-	result = pstore.NewConsumerWithMetricsBuilder(writer)
-	result.SetConcurrency(c.Concurrency)
-	result.SetBufferSize(c.BatchSize)
-	result.SetRollUpSpan(c.RollUpSpan)
-	result.SetName(c.Name)
-	return
+	builder := pstore.NewConsumerWithMetricsBuilder(writer)
+	if d.RecordsPerSecond > 0 {
+		builder.SetRecordsPerSecond(d.RecordsPerSecond)
+	}
+	if d.DebugMetricRegex != "" || d.DebugHostRegex != "" {
+		var hook pstore.RecordWriterHook
+		hook, err = newWriterHook(
+			d.DebugMetricRegex, d.DebugHostRegex, d.DebugFilePath)
+		if err != nil {
+			return
+		}
+		builder.AddWriterHook(hook)
+	}
+	builder.SetConcurrency(c.Concurrency)
+	builder.SetBufferSize(c.BatchSize)
+	builder.SetRollUpSpan(c.RollUpSpan)
+	builder.SetName(c.Name)
+	return builder, nil
 }
 
 func createConsumerBuilders(c ConsumerBuilderFactoryList) (

--- a/pstore/config/config_test.go
+++ b/pstore/config/config_test.go
@@ -38,10 +38,6 @@ type configPlus struct {
 	Consumer config.ConsumerConfig `yaml:"consumer"`
 }
 
-func (c *configPlus) NewWriter() (pstore.LimitedRecordWriter, error) {
-	return c.Options.NewThrottledWriter(&c.Writer)
-}
-
 func (c *configPlus) NewConsumerBuilder() (
 	*pstore.ConsumerWithMetricsBuilder, error) {
 	return c.Consumer.NewConsumerBuilder(&c.Writer, &c.Options)

--- a/pstore/influx/api.go
+++ b/pstore/influx/api.go
@@ -60,10 +60,6 @@ type ConfigPlus struct {
 	Consumer config.ConsumerConfig `yaml:"consumer"`
 }
 
-func (c *ConfigPlus) NewWriter() (pstore.LimitedRecordWriter, error) {
-	return c.Options.NewThrottledWriter(&c.Writer)
-}
-
 func (c *ConfigPlus) NewConsumerBuilder() (
 	*pstore.ConsumerWithMetricsBuilder, error) {
 	return c.Consumer.NewConsumerBuilder(&c.Writer, &c.Options)

--- a/pstore/kafka/api.go
+++ b/pstore/kafka/api.go
@@ -80,10 +80,6 @@ type ConfigPlus struct {
 	Consumer config.ConsumerConfig `yaml:"consumer"`
 }
 
-func (c *ConfigPlus) NewWriter() (pstore.LimitedRecordWriter, error) {
-	return c.Options.NewThrottledWriter(&c.Writer)
-}
-
 func (c *ConfigPlus) NewConsumerBuilder() (
 	*pstore.ConsumerWithMetricsBuilder, error) {
 	return c.Consumer.NewConsumerBuilder(&c.Writer, &c.Options)

--- a/pstore/pstore.go
+++ b/pstore/pstore.go
@@ -11,32 +11,30 @@ const (
 	kDefaultBufferSize = 1000
 )
 
-type throttleWriter struct {
-	LimitedRecordWriter
-	recordsPerSecond int
+type hookWriter struct {
+	wrapped RecordWriter
+	hooks   []RecordWriterHook
 }
 
-func newThrottledLimitedRecordWriter(
-	w LimitedRecordWriter,
-	recordsPerSecond int) ThrottledLimitedRecordWriter {
-	if recordsPerSecond < 0 {
-		recordsPerSecond = 0
+func (h *hookWriter) Write(records []Record) error {
+	result := h.wrapped.Write(records)
+	for _, hook := range h.hooks {
+		hook.WriteCalled(records, result)
 	}
-	return &throttleWriter{
-		LimitedRecordWriter: w,
-		recordsPerSecond:    recordsPerSecond}
+	return result
 }
 
-func (t *throttleWriter) RecordsPerSecond() int {
-	return t.recordsPerSecond
+type throttleWriter struct {
+	wrapped          RecordWriter
+	recordsPerSecond int
 }
 
 func (t *throttleWriter) Write(records []Record) error {
 	if t.recordsPerSecond <= 0 {
-		return t.LimitedRecordWriter.Write(records)
+		return t.wrapped.Write(records)
 	}
 	now := time.Now()
-	result := t.LimitedRecordWriter.Write(records)
+	result := t.wrapped.Write(records)
 	throttleDuration := time.Second * time.Duration(len(records)) / time.Duration(t.recordsPerSecond)
 	timeToBeDone := now.Add(throttleDuration)
 	now = time.Now()
@@ -327,23 +325,36 @@ func toFilterer(typeFilter func(types.Type) bool) store.Filterer {
 }
 
 func newConsumerWithMetricsBuilder(
-	w ThrottledLimitedRecordWriter) *ConsumerWithMetricsBuilder {
+	w LimitedRecordWriter) *ConsumerWithMetricsBuilder {
 	writerWithMetrics := &RecordWriterWithMetrics{W: w}
 	ptr := &ConsumerWithMetrics{
 		attributes: ConsumerAttributes{
-			RecordsPerSecond: w.RecordsPerSecond(),
-			BatchSize:        kDefaultBufferSize,
-			Concurrency:      1},
+			BatchSize:   kDefaultBufferSize,
+			Concurrency: 1},
 		metricsStore: &ConsumerMetricsStore{
 			w:        writerWithMetrics,
 			filterer: toFilterer(w.IsTypeSupported),
 		},
 	}
-	return &ConsumerWithMetricsBuilder{c: &ptr}
+	return &ConsumerWithMetricsBuilder{c: ptr}
 }
 
 func (b *ConsumerWithMetricsBuilder) build() *ConsumerWithMetrics {
-	result := *b.c
+	result := b.c
+	// fixup writer
+	writer := result.metricsStore.w.W
+	if result.attributes.RecordsPerSecond > 0 {
+		writer = &throttleWriter{
+			wrapped:          writer,
+			recordsPerSecond: result.attributes.RecordsPerSecond,
+		}
+	}
+	if len(b.hooks) > 0 {
+		writer = &hookWriter{
+			wrapped: writer,
+			hooks:   b.hooks}
+	}
+	result.metricsStore.w.W = writer
 	if result.attributes.Concurrency == 1 {
 		result.consumer = toConsumerType(
 			NewConsumer(
@@ -357,6 +368,7 @@ func (b *ConsumerWithMetricsBuilder) build() *ConsumerWithMetrics {
 	} else {
 		panic("pstore: Oops, bad state in build method.")
 	}
-	*b.c = nil
+	b.c = nil
+	b.hooks = nil
 	return result
 }

--- a/pstore/tsdb/api.go
+++ b/pstore/tsdb/api.go
@@ -51,10 +51,6 @@ type ConfigPlus struct {
 	Consumer config.ConsumerConfig `yaml:"consumer"`
 }
 
-func (c *ConfigPlus) NewWriter() (pstore.LimitedRecordWriter, error) {
-	return c.Options.NewThrottledWriter(&c.Writer)
-}
-
 func (c *ConfigPlus) NewConsumerBuilder() (
 	*pstore.ConsumerWithMetricsBuilder, error) {
 	return c.Consumer.NewConsumerBuilder(&c.Writer, &c.Options)


### PR DESCRIPTION
Also allow clients to add hooks to writes such as running the GC.
