### PR TITLE
Fix bug 1586.

### DIFF
--- a/pstore/api.go
+++ b/pstore/api.go
@@ -171,7 +171,7 @@ func (a *AsyncConsumer) Flush() {
 type Consumer struct {
 	w             RecordWriter
 	buffer        []Record
-	toBeCommitted map[store.NamedIterator]bool
+	toBeCommitted []store.NamedIterator
 	idx           int
 }
 


### PR DESCRIPTION
Now progress continues even if all remaining values on an iterator
cannot be written to underlying pstore.
