### PR TITLE
Don't change units.Unknown to units.None in scotty.

### DIFF
--- a/messages/api.go
+++ b/messages/api.go
@@ -32,9 +32,9 @@ type EndpointMetric struct {
 	HostName    string               `json:"hostName,omitempty"`
 	Path        string               `json:"path,omitempty"`
 	Description string               `json:"description"`
-	Unit        units.Unit           `json:"unit"`
+	Unit        units.Unit           `json:"unit,omitempty"`
 	Kind        types.Type           `json:"kind"`
-	SubType     types.Type           `json:"subType"`
+	SubType     types.Type           `json:"subType,omitempty"`
 	Bits        int                  `json:"bits,omitempty"`
 	Values      TimestampedValueList `json:"values"`
 }

--- a/store/seriescollection.go
+++ b/store/seriescollection.go
@@ -4,7 +4,6 @@ import (
 	"github.com/Symantec/scotty/metrics"
 	"github.com/Symantec/tricorder/go/tricorder/duration"
 	"github.com/Symantec/tricorder/go/tricorder/types"
-	"github.com/Symantec/tricorder/go/tricorder/units"
 	"strings"
 	"sync"
 )
@@ -235,13 +234,6 @@ func (c *timeSeriesCollectionType) TsByPrefix(prefix string) (
 	return
 }
 
-func indexOf(mlist metrics.List, i int, avalue *metrics.Value) {
-	mlist.Index(i, avalue)
-	if avalue.Unit == "" {
-		avalue.Unit = units.None
-	}
-}
-
 // LookupBatch looks up all the metrics in one go and returns the
 // following:
 // fetched: timeSeries already in this collection keyed by Metric.
@@ -277,7 +269,7 @@ func (c *timeSeriesCollectionType) LookupBatch(
 	mlen := mlist.Len()
 	for i := 0; i < mlen; i++ {
 		var avalue metrics.Value
-		indexOf(mlist, i, &avalue)
+		mlist.Index(i, &avalue)
 		kind, subType := types.FromGoValueWithSubType(avalue.Value)
 		// TODO: Allow distribution metrics later.
 		if kind == types.Dist {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1262,7 +1262,7 @@ func TestMetaData(t *testing.T) {
 	assertValueEquals(t, "none", result[0].Info.Description())
 	assertValueEquals(t, 0, result[0].Info.GroupId())
 	assertValueEquals(t, types.Uint8, result[0].Info.Kind())
-	assertValueEquals(t, units.None, result[0].Info.Unit())
+	assertValueEquals(t, units.Unknown, result[0].Info.Unit())
 
 	result = nil
 	aStore.ByNameAndEndpoint(


### PR DESCRIPTION
In this PR, I allow metrics with unknown units to be pushed to scotty as is. I no longer change them to units.None. In this PR, I also make the units field in the scotty JSON optional as the units may be unknown. This shouldn't break anyone as there are no known clients of scotty just yet.
