### PR TITLE
Rough draft of scotty JSON for distributions.

### DIFF
--- a/messages/api.go
+++ b/messages/api.go
@@ -6,16 +6,6 @@ import (
 	"github.com/Symantec/tricorder/go/tricorder/units"
 )
 
-// Range represents a range for distribution values
-type Range struct {
-	// Represents the lower bound of the range inclusive.
-	// Ignore for the first (lowest) range which never has a lower bound.
-	Lower float64 `json:"lower"`
-	// Represents the upper bound of the range exclusive.
-	// Ignore for the highest (last) range which never has a upper bound.
-	Upper float64 `json:"upper"`
-}
-
 // Distribution represents a distribution of values since the previous
 // distribution.
 //
@@ -32,8 +22,8 @@ type Distribution struct {
 	Sum float64 `json:"sum"`
 	// The total number of values since last recorded distribution
 	Count uint64 `json:"count"`
-	// The number of values within each range. Always the same length as
-	// the Buckets field in the EndpointMetric structure
+	// The number of values within each range. Length is always one more
+	// than length of UpperLimis field in the EndpointMetric structure
 	Counts []int64 `json:"counts"`
 }
 
@@ -78,8 +68,8 @@ type EndpointMetric struct {
 
 	// This field is true if this distribution is not cumulative.
 	IsNotCumulative bool `json:"isNotCumulative,omitempty"`
-	// The buckets for the distribution.
-	Buckets []Range `json:"buckets,omitempty"`
+	// The upper limits for the distribution buckets.
+	UpperLimits []float64 `json:"upperLimits,omitempty"`
 }
 
 // EndpointMetricList represents a list of EndpointMetric. Client should

--- a/messages/api.go
+++ b/messages/api.go
@@ -21,8 +21,10 @@ type Range struct {
 //
 // The Value field of the TimestampedValue struct will hold
 // a *Distribution for distributions. For the earliest reported timestamp,
-// Value always contains a nil *Distribution pointer since in that case
-// there is no previous distribution.
+// Value always contains, the zero distribution, a nil *Distribution pointer,
+// since in that case there is no previous distribution. Likewise, if an
+// endpoint is restarted between collections, scotty will store the zero
+// distribution to indicate a restart
 //
 // Distribution instances should be treated as immutable.
 type Distribution struct {
@@ -45,7 +47,8 @@ type TimestampedValue struct {
 	Timestamp string `json:"timestamp"`
 	// value stored here. zero equivalent stored for inactive markers.
 	// For lists, the zero equivalent is an empty list.
-	// For distributions, the zero equivalent is nil or for JSON, None.
+	// For distributions, the zero equivalent is nil *Distribution
+	// or for JSON, None.
 	Value interface{} `json:"value"`
 	// True for real values, false for inactive markers. Used to
 	// distinguish inactive markers from real 0 values.

--- a/store/api.go
+++ b/store/api.go
@@ -15,6 +15,12 @@ var (
 	ErrInactive = errors.New("store: endpoint inactive.")
 )
 
+// Ranges depicts the ranges for a distributions.
+// Instances of this type must be treated as immutable
+type Ranges struct {
+	Ranges []float64
+}
+
 // MetricInfo represents the meta data for a metric
 // MetricInfo instances are immutable by contract
 type MetricInfo struct {
@@ -23,7 +29,14 @@ type MetricInfo struct {
 	unit        units.Unit
 	kind        types.Type
 	subType     types.Type
-	groupId     int
+	// A pointer so that MetricInfo can be a map key. If the path field
+	// differs between two structs, this field will differ also even
+	// if the ranges are logically equal. However, if the path field
+	// is equal between two structs, this field will also be equal if
+	// and only if the ranges are logically equivalent.
+	ranges          *Ranges
+	isNotCumulative bool
+	groupId         int
 }
 
 // Path returns the path of the metric
@@ -56,6 +69,18 @@ func (m *MetricInfo) Bits() int {
 		return m.subType.Bits()
 	}
 	return m.kind.Bits()
+}
+
+// Ranges returns the ranges of the distribution when Kind() == types.Dist,
+// otherwise returns nil.
+func (m *MetricInfo) Ranges() *Ranges {
+	return m.ranges
+}
+
+// IsNotCumulative returns true when Kind() == types.Dist and distribution
+// is not cumulative. Returns false in all other cases.
+func (m *MetricInfo) IsNotCumulative() bool {
+	return m.isNotCumulative
 }
 
 // The group ID of this metric


### PR DESCRIPTION
Here is a strawman of how scotty will present distribution metrics it has collected in json.  Scotty will report distribution values only when they change just as scotty reports scalar values only when they change. 

In this PR, scotty provides only delta distribution statistics each time. For example, if scotty collects data once every 5 minutes, it will provide distribution statistics in 5 minute intervals.  If an endpoint goes down and is brought back up between collections, scotty will detect this with the help of the generationId field and will show no distribution for that particular interval.

Clients of scotty will aggregate distribution times for themselves. For instance, if a client wants RPC latency between 11:00 and 12:00, it will ask scotty for all the delta distributions between 11:00 and 12:00 and aggregate for itself. This gives the client the freedom to deal with endpoint restarts how it chooses.  For instance, if a restart happened between 11:00 and 12:00, the client could ignore it and just approximate the distribution for that hour, or the client could build one distribution before the restart and one after the restart.
