### PR TITLE
Introduce metric grouping strategies.

### DIFF
--- a/store/appenders_test.go
+++ b/store/appenders_test.go
@@ -1,0 +1,74 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeNewestFirst(t *testing.T) {
+	series := [][]Record{
+		{
+			{TimeStamp: 999.0},
+			{TimeStamp: 666.0},
+			{TimeStamp: 333.0},
+			{Value: 3, TimeStamp: 222.0},
+		},
+		{},
+		{
+			{TimeStamp: 777.0},
+		},
+		{
+			{TimeStamp: 985.0},
+			{TimeStamp: 923.0},
+			{TimeStamp: 222.0, Active: true},
+		},
+	}
+	var result []Record
+	mergeNewestFirst(series, AppendTo(&result))
+	expected := []Record{
+		{TimeStamp: 999.0},
+		{TimeStamp: 985.0},
+		{TimeStamp: 923.0},
+		{TimeStamp: 777.0},
+		{TimeStamp: 666.0},
+		{TimeStamp: 333.0},
+		{TimeStamp: 222.0, Active: true},
+	}
+	if !reflect.DeepEqual(expected, result) {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+func TestMergeOldestFirst(t *testing.T) {
+	series := [][]Record{
+		{
+			{TimeStamp: 222.0, Active: true},
+			{TimeStamp: 333.0},
+			{TimeStamp: 666.0},
+			{TimeStamp: 999.0},
+		},
+		{},
+		{
+			{TimeStamp: 777.0},
+		},
+		{
+			{Value: 3, TimeStamp: 222.0},
+			{TimeStamp: 923.0},
+			{TimeStamp: 985.0},
+		},
+	}
+	var result []Record
+	mergeOldestFirst(series, AppendTo(&result))
+	expected := []Record{
+		{TimeStamp: 222.0, Active: true},
+		{TimeStamp: 333.0},
+		{TimeStamp: 666.0},
+		{TimeStamp: 777.0},
+		{TimeStamp: 923.0},
+		{TimeStamp: 985.0},
+		{TimeStamp: 999.0},
+	}
+	if !reflect.DeepEqual(expected, result) {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}

--- a/store/partition.go
+++ b/store/partition.go
@@ -1,0 +1,77 @@
+package store
+
+// partitionType is the interface for partitions
+type partitionType interface {
+	// Len returns the length of the slice
+	Len() int
+	// SubsetId returns the subset Id at element index.
+	SubsetId(index int) interface{}
+}
+
+// formPartitionType instance can be mutated in place to form partitions
+type formPartitionType interface {
+	partitionType
+	// Swap ith and jth element
+	Swap(i, j int)
+}
+
+// formPartition forms a partition out of p
+func formPartition(p formPartitionType) {
+	counts := make(map[interface{}]int)
+	length := p.Len()
+	for i := 0; i < length; i++ {
+		counts[p.SubsetId(i)]++
+	}
+	partitionOffsets := &partitionOffsetType{
+		counts: counts,
+		ranges: make(map[interface{}]sliceRangeType, len(counts)),
+	}
+	for i := 0; i < length; i++ {
+		dest := partitionOffsets.offsetOf(p.SubsetId(i), i)
+		for i < dest {
+			p.Swap(i, dest)
+			dest = partitionOffsets.offsetOf(p.SubsetId(i), i)
+		}
+	}
+}
+
+// nextSubset returns the starting index of the next subset in p.
+// idx is the first index of the current subset.
+// To iterate over all the subsets, caller should start with idx = 0.
+// nextSubset returns len(p) when there are no more subsets.
+func nextSubset(p partitionType, idx int) int {
+	id := p.SubsetId(idx)
+	length := p.Len()
+	for i := idx + 1; i < length; i++ {
+		if p.SubsetId(i) != id {
+			return i
+		}
+	}
+	return length
+}
+
+type sliceRangeType struct {
+	start int
+	end   int
+}
+
+type partitionOffsetType struct {
+	counts         map[interface{}]int
+	ranges         map[interface{}]sliceRangeType
+	farthestOffset int
+}
+
+func (p *partitionOffsetType) offsetOf(id interface{}, index int) int {
+	arange, ok := p.ranges[id]
+	if !ok {
+		arange.start = p.farthestOffset
+		arange.end = p.farthestOffset
+		p.farthestOffset += p.counts[id]
+	}
+	if index >= arange.start && index < arange.end {
+		return index
+	}
+	arange.end++
+	p.ranges[id] = arange
+	return arange.end - 1
+}

--- a/store/partition_test.go
+++ b/store/partition_test.go
@@ -1,0 +1,90 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+type intPartitionForTestingType []int
+
+func (p intPartitionForTestingType) Swap(i, j int) {
+	p[j], p[i] = p[i], p[j]
+}
+
+func (p intPartitionForTestingType) SubsetId(index int) interface{} {
+	return p[index] / 10
+}
+
+func (p intPartitionForTestingType) Len() int {
+	return len(p)
+}
+
+func TestPartitionScrambled(t *testing.T) {
+	scrambled := intPartitionForTestingType{
+		44, 32, 43, 42, 41, 54, 21, 3, 53, 2, 31, 1, 52, 51}
+	formPartition(scrambled)
+	verifyPartition(t, scrambled)
+}
+
+func TestPartitionPreserveOrderWhenPossible(t *testing.T) {
+	ordered := intPartitionForTestingType{
+		44, 32, 31, 7, 6, 5, 19, 17, 23}
+	expected := make(intPartitionForTestingType, len(ordered))
+	copy(expected, ordered)
+	formPartition(ordered)
+	if !reflect.DeepEqual(expected, ordered) {
+		t.Error("Expect formPartition to preserve order when possible")
+	}
+	verifyPartition(t, ordered)
+}
+
+func TestPartitionPreserveOrderWhenPossibleOnePartition(t *testing.T) {
+	ordered := intPartitionForTestingType{
+		109, 101, 108, 102, 107, 103, 106}
+	expected := make(intPartitionForTestingType, len(ordered))
+	copy(expected, ordered)
+	formPartition(ordered)
+	if !reflect.DeepEqual(expected, ordered) {
+		t.Error("Expect formPartition to preserve order when possible")
+	}
+	verifyPartition(t, ordered)
+}
+
+func verifyPartition(t *testing.T, partition intPartitionForTestingType) {
+	length := len(partition)
+	groupsvisited := make(map[int]bool)
+	needToVisit := make(map[int]bool, length)
+	for i := range partition {
+		needToVisit[partition[i]] = true
+	}
+	for startIdx, endIdx := 0, 0; startIdx < length; startIdx = endIdx {
+		endIdx = nextSubset(partition, startIdx)
+		group := partition[startIdx:endIdx]
+		if groupsvisited[group[0]/10] {
+			t.Errorf("Group visited: %v", group)
+		}
+		groupsvisited[group[0]/10] = true
+		notAGroup := false
+		for i := range group {
+			if !needToVisit[group[i]] {
+				t.Errorf("Unexpected group memeber: %d", group[i])
+			}
+			delete(needToVisit, group[i])
+			if group[i]/10 != group[0]/10 {
+				notAGroup = true
+			}
+		}
+		if notAGroup {
+			t.Errorf("Not a group: %v", group)
+		}
+	}
+	assertValueEquals(t, 0, len(needToVisit))
+}
+
+func assertValueEquals(t *testing.T, expected, actual interface{}) bool {
+	if expected != actual {
+		t.Errorf("Expected %v, got %v", expected, actual)
+		return false
+	}
+	return true
+}

--- a/store/store.go
+++ b/store/store.go
@@ -63,16 +63,20 @@ func (s *Store) byNameAndEndpoint(
 	name string,
 	endpointId interface{},
 	start, end float64,
+	strategy MetricGroupingStrategy,
 	result Appender) {
-	s.byApplication[endpointId].ByName(name, start, end, result)
+	s.byApplication[endpointId].ByName(
+		name, start, end, strategy, result)
 }
 
 func (s *Store) byPrefixAndEndpoint(
 	prefix string,
 	endpointId interface{},
 	start, end float64,
+	strategy MetricGroupingStrategy,
 	result Appender) {
-	s.byApplication[endpointId].ByPrefix(prefix, start, end, result)
+	s.byApplication[endpointId].ByPrefix(
+		prefix, start, end, strategy, result)
 }
 
 func (s *Store) timeLeft(name string) float64 {
@@ -105,8 +109,10 @@ func (s *Store) namedIteratorForEndpointRollUp(
 func (s *Store) byEndpoint(
 	endpointId interface{},
 	start, end float64,
+	strategy MetricGroupingStrategy,
 	result Appender) {
-	s.byApplication[endpointId].ByPrefix("", start, end, result)
+	s.byApplication[endpointId].ByPrefix(
+		"", start, end, strategy, result)
 }
 
 func (s *Store) markEndpointInactive(


### PR DESCRIPTION
Here is the first part of the fix for bug 1804.

This fix is a recommended part of supporting distributions in scotty.

In this PR, I introduce metric grouping strategies. A metric grouping strategy is a strategy for determining whether or not two different time series in scotty belong to the same metric.

It used to be that there was always 1:1 relationship between time series in scotty and metrics in scotty. Now, that is no longer the case. Now, each time series in scotty is linked to a particular group of timestamps so that scotty does not have to store all the same timestamps over and over again for multiple metrics. As endpoints are recompiled, the group ID for a particular metric can change over time causing the same metric to be stored in multiple timeseries within scotty. How do we decide what time series belong to what metrics? Enter metric grouping strategies.

A metric grouping strategy forms an equivalence relation out of time series so that equivalent time series belong to the same metric. a store.MetricGroupingStrategy is a simple go function that takes as input the unique identifier of a time series as input and outputs a key. Two time series belong to the same metric if and only if the metric grouping strategy function returns the same value for their unique identifier.

Before this PR, we had only one metric grouping strategy: No two time series belonged to the same metric. The store.GroupMetricExactly strategy depicts this grouping strategy. store.GroupMetricExactly returns the time series unique identifier as is so that no two time series will match.

In this PR, we introduce the store.GroupMetricByKey strategy. This strategy says that two time series belong to the same metric if and only if their identification differs only by group id and nothing else. This way, if the group ID of a metric changes over time so that its values are stored in multiple time series, these time series can still be considered part of the same metric.

All of the ByXXXAndEndpoint() methods on store.Store still work the same grouping metrics using the store.GroupMetricExactly strategy. However, in this PR, I introduce ByXXXAndEndpointStrategy() methods where caller can provide the strategy to use to group metrics. These methods are useful for the part of scotty that emits the JSON for a metric as they allow the values to be grouped in a way that a human would expect, not how scotty does it internally.

I can extend the metric grouping strategy to scotty persistent stores as well. persistent stores generally consider a metric value to be a name and a floating point value. Our persistent stores don't care about any other metric meta data including the metric description. Therefore, if an endpoint decides to change the description of a metric while scotty is running, scotty should still consider it part of the same metric when writing to a persistent store rather than two different metrics, each with a different description. 

For rolling up up metrics when storing to persistent store, the grouping strategy abstraction is even more important because it defines how scotty identifies whether two different time series belong to the same metric and should be rolled together or if two different time series are in fact two different metrics that should be rolled up separately. Currently, the reader is left guessing how scotty defines two metrics as being the same. In fact, scotty does it in a way a human would not expect.

In a future PR, I introduce the store.GroupMetricByPathAndNumeric strategy which considers only the path of a metric and whether or not it is numeric, and I change the iterator system to honor strategies. 
