### PR TITLE
int to uint conversion.

### DIFF
--- a/api.go
+++ b/api.go
@@ -122,7 +122,7 @@ type Logger interface {
 // Endpoint instances are safe to use with multiple goroutines.
 type Endpoint struct {
 	host           string
-	port           int
+	port           uint
 	connector      sources.Connector
 	onePollAtATime chan bool
 	state          *State
@@ -132,7 +132,7 @@ type Endpoint struct {
 // NewEndpointWithConnector creates a new endpoint for given host, port
 // and connector.
 func NewEndpointWithConnector(
-	hostname string, port int, connector sources.Connector) *Endpoint {
+	hostname string, port uint, connector sources.Connector) *Endpoint {
 	return newEndpoint(hostname, port, connector)
 }
 
@@ -142,7 +142,7 @@ func (e *Endpoint) HostName() string {
 }
 
 // Port returns the port to collect metrics.
-func (e *Endpoint) Port() int {
+func (e *Endpoint) Port() uint {
 	return e.port
 }
 
@@ -164,24 +164,24 @@ func (e *Endpoint) Poll(sweepStartTime time.Time, logger Logger) {
 // SetConcurrentPolls sets the maximum number of concurrent polls.
 // Call SetConcurrentPolls at the beginning of the main() function before
 // calling Endpoint.Poll
-func SetConcurrentPolls(x int) {
+func SetConcurrentPolls(x uint) {
 	setConcurrentPolls(x)
 }
 
 // ConcurrentPolls returns the maximum number of concurrent polls.
 // Default is 2 * number of CPUs
-func ConcurrentPolls() int {
+func ConcurrentPolls() uint {
 	return concurrentPolls
 }
 
 // SetConcurrentConnects sets the maximum number of concurrent connects.
 // Call SetConcurrentConnects at the beginning of the main() function before
 // calling Endpoint.Poll
-func SetConcurrentConnects(x int) {
+func SetConcurrentConnects(x uint) {
 	setConcurrentConnects(x)
 }
 
 // ConcurrentConnects returns the maximum number of concurrent connects.
-func ConcurrentConnects() int {
+func ConcurrentConnects() uint {
 	return concurrentConnects
 }

--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -52,11 +52,11 @@ var (
 		"portNum",
 		6980,
 		"Port number for scotty.")
-	fBytesPerPage = flag.Int(
+	fBytesPerPage = flag.Uint(
 		"bytes_per_page",
 		1024,
 		"Space for new metrics for each endpoint in records")
-	fPageCount = flag.Int(
+	fPageCount = flag.Uint(
 		"page_count",
 		30*1000*1000,
 		"Total page count")
@@ -68,11 +68,11 @@ var (
 		"mdb_file",
 		"/var/lib/Dominator/mdb",
 		"Name of file from which to read mdb data.")
-	fPollCount = flag.Int(
+	fPollCount = flag.Uint(
 		"poll_count",
 		collector.ConcurrentPolls(),
 		"Maximum number of concurrent polls")
-	fConnectionCount = flag.Int(
+	fConnectionCount = flag.Uint(
 		"connection_count",
 		collector.ConcurrentConnects(),
 		"Maximum number of concurrent connections")
@@ -104,7 +104,7 @@ var (
 		"inactiveThreshhold", 0.1, "Ratio of inactive pages needed to begin purging inactive pages")
 	fFreedPageRatio = flag.Float64(
 		"freedPageRatio", 0.05, "Ratio of pages freed each time a GC does not bring memory usage down to the goal")
-	fDegree = flag.Int(
+	fDegree = flag.Uint(
 		"degree", 10, "Degree of btree")
 	fPagePercentage = flag.Float64(
 		"page_percentage", 50.0, "Percentage of allocated memory used for pages")
@@ -828,13 +828,13 @@ func createApplicationList() *datastructs.ApplicationList {
 	return builder.Build()
 }
 
-func computePageCount() int {
+func computePageCount() uint {
 	totalMemoryToUse, err := sysmemory.TotalMemoryToUse()
 	if err != nil {
 		log.Fatal(err)
 	}
 	if totalMemoryToUse > 0 {
-		return int(totalMemoryToUse / uint64(*fBytesPerPage))
+		return uint(totalMemoryToUse / uint64(*fBytesPerPage))
 	}
 	return *fPageCount
 }
@@ -860,7 +860,7 @@ func totalSystemMemory() uint64 {
 }
 
 type memoryManagerType struct {
-	pagesToUse    int
+	pagesToUse    uint
 	targetAlloc   uint64
 	highWaterMark uint64
 	lowWaterMark  uint64
@@ -905,7 +905,7 @@ func maybeCreateMemoryManager(logger *log.Logger) *memoryManagerType {
 			logger:        logger,
 			gcCh:          make(chan bool),
 		}
-		result.pagesToUse = int(result.lowWaterMark / uint64(*fBytesPerPage))
+		result.pagesToUse = uint(result.lowWaterMark / uint64(*fBytesPerPage))
 		go result.loop()
 		return result
 	}
@@ -919,7 +919,7 @@ func (m *memoryManagerType) UseMemoryAdjustment(
 	m.adjustment = adjustment
 }
 
-func (m *memoryManagerType) PagesToUseInitially() int {
+func (m *memoryManagerType) PagesToUseInitially() uint {
 	return m.pagesToUse
 }
 

--- a/datastructs/api.go
+++ b/datastructs/api.go
@@ -32,13 +32,13 @@ type ApplicationStatus struct {
 	LastErrorTime time.Time
 
 	// Initial metric count
-	InitialMetricCount int
+	InitialMetricCount uint
 
 	// Whether or not it is currently down.
 	Down bool
 
-	changedMetrics_Sum   int64
-	changedMetrics_Count int64
+	changedMetrics_Sum   uint64
+	changedMetrics_Count uint64
 }
 
 // Returns last error time as 2006-01-02T15:04:05
@@ -141,7 +141,7 @@ func (a *ApplicationStatuses) MarkHostsActiveExclusively(
 // This instance must have prior knowledge of e. That is, e must come from
 // a method such as ActiveEndpointIds(). Otherwise, this method panics.
 func (a *ApplicationStatuses) LogChangedMetricCount(
-	e *scotty.Endpoint, metricCount int) {
+	e *scotty.Endpoint, metricCount uint) {
 	a.logChangedMetricCount(e, metricCount)
 }
 
@@ -171,7 +171,7 @@ func (a *ApplicationStatuses) ActiveEndpointIds() (
 type Application struct {
 	name      string
 	connector sources.Connector
-	port      int
+	port      uint
 }
 
 // Name returns the name of application
@@ -185,14 +185,14 @@ func (a *Application) Connector() sources.Connector {
 }
 
 // Port returns the port number of the application
-func (a *Application) Port() int {
+func (a *Application) Port() uint {
 	return a.port
 }
 
 // ApplicationList represents all the applications in the fleet.
 // ApplicationList instances are immutable.
 type ApplicationList struct {
-	byPort map[int]*Application
+	byPort map[uint]*Application
 	byName map[string]*Application
 }
 
@@ -204,7 +204,7 @@ func (a *ApplicationList) All() []*Application {
 
 // ByPort returns the application running on a particular port or nil
 // if no application is using port.
-func (a *ApplicationList) ByPort(port int) *Application {
+func (a *ApplicationList) ByPort(port uint) *Application {
 	return a.byPort[port]
 }
 
@@ -225,7 +225,7 @@ func NewApplicationListBuilder() *ApplicationListBuilder {
 
 // Add adds an application.
 func (a *ApplicationListBuilder) Add(
-	port int, applicationName string, connector sources.Connector) {
+	port uint, applicationName string, connector sources.Connector) {
 	a.add(port, applicationName, connector)
 }
 

--- a/datastructs/datastructs.go
+++ b/datastructs/datastructs.go
@@ -37,7 +37,7 @@ var (
 
 type hostAndPort struct {
 	Host string
-	Port int
+	Port uint
 }
 
 func (a *ApplicationStatuses) newApplicationStatus(
@@ -166,7 +166,7 @@ func (a *ApplicationStatuses) markHostsActiveExclusively(
 }
 
 func (a *ApplicationStatuses) logChangedMetricCount(
-	e *scotty.Endpoint, metricCount int) {
+	e *scotty.Endpoint, metricCount uint) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	record := a.byEndpoint[e]
@@ -176,7 +176,7 @@ func (a *ApplicationStatuses) logChangedMetricCount(
 	if record.InitialMetricCount == 0 {
 		record.InitialMetricCount = metricCount
 	} else {
-		record.changedMetrics_Sum += int64(metricCount)
+		record.changedMetrics_Sum += uint64(metricCount)
 		record.changedMetrics_Count++
 	}
 }
@@ -234,14 +234,14 @@ func (a *ApplicationList) all() (result []*Application) {
 
 func newApplicationListBuilder() *ApplicationListBuilder {
 	list := &ApplicationList{
-		byPort: make(map[int]*Application),
+		byPort: make(map[uint]*Application),
 		byName: make(map[string]*Application),
 	}
 	return &ApplicationListBuilder{listPtr: &list}
 }
 
 func (a *ApplicationListBuilder) add(
-	port int, applicationName string, connector sources.Connector) {
+	port uint, applicationName string, connector sources.Connector) {
 	if (*a.listPtr).byPort[port] != nil || (*a.listPtr).byName[applicationName] != nil {
 		panic("Both name and port must be unique.")
 	}
@@ -260,7 +260,7 @@ func (a *ApplicationListBuilder) build() *ApplicationList {
 type configLineType struct {
 	Name     string
 	Protocol string
-	Port     int
+	Port     uint
 	Params   map[string]string
 }
 

--- a/datastructs/datastructs_test.go
+++ b/datastructs/datastructs_test.go
@@ -83,11 +83,11 @@ func TestConfigFile(t *testing.T) {
 	if len(applications) != 3 {
 		t.Error("Expected 3 applications.")
 	}
-	portAndName := make(map[int]string)
+	portAndName := make(map[uint]string)
 	for _, app := range applications {
 		portAndName[app.Port()] = app.Name()
 	}
-	expected := map[int]string{
+	expected := map[uint]string{
 		2222: "An application",
 		6910: "Health Metrics",
 		6970: "Dominator",
@@ -164,9 +164,9 @@ func newStore(
 	t *testing.T,
 	testName string,
 	valueCount,
-	pageCount int,
+	pageCount uint,
 	inactiveThreshhold float64,
-	degree int) *store.Store {
+	degree uint) *store.Store {
 	result := store.NewStore(
 		valueCount, pageCount, inactiveThreshhold, degree)
 	dirSpec, err := tricorder.RegisterDirectory("/" + testName)
@@ -235,7 +235,7 @@ func TestMarkHostsActiveExclusively(t *testing.T) {
 	endpointId, aStore := appStatus.EndpointIdByHostAndName(
 		"host3", "AnApp")
 	assertValueEquals(t, "host3", endpointId.HostName())
-	assertValueEquals(t, 35, endpointId.Port())
+	assertValueEquals(t, uint(35), endpointId.Port())
 
 	// Trying to add to inactive endpoint should fail
 	if _, err := aStore.AddBatch(endpointId, 9999.0, metrics.SimpleList(nil)); err != store.ErrInactive {
@@ -505,7 +505,7 @@ func assertValueEquals(
 
 func assertApplication(
 	t *testing.T,
-	port int,
+	port uint,
 	name string,
 	protocol string,
 	app *Application) {

--- a/pstore/api.go
+++ b/pstore/api.go
@@ -134,7 +134,7 @@ func (w *RecordWriterWithMetrics) Metrics(m *RecordWriterMetrics) {
 type AsyncConsumer struct {
 	requests     chan consumerRequestType
 	flushBarrier *barrier
-	concurrency  int
+	concurrency  uint
 }
 
 // NewAsyncConsumer creates a new AsyncConsumer instance.
@@ -142,7 +142,7 @@ type AsyncConsumer struct {
 // concurrency is the count of goroutines doing the consuming.
 // bufferSize is the size of each buffer. Each goroutine gets its own buffer.
 func NewAsyncConsumer(
-	w RecordWriter, bufferSize, concurrency int) *AsyncConsumer {
+	w RecordWriter, bufferSize, concurrency uint) *AsyncConsumer {
 	return newAsyncConsumer(w, bufferSize, concurrency)
 }
 
@@ -185,7 +185,7 @@ type Consumer struct {
 
 // NewConsumer creates a new Consumer instance. w is the underlying writer.
 // bufferSize is how many values the buffer holds.
-func NewConsumer(w RecordWriter, bufferSize int) *Consumer {
+func NewConsumer(w RecordWriter, bufferSize uint) *Consumer {
 	return newConsumer(w, bufferSize)
 }
 
@@ -261,11 +261,11 @@ func (s *ConsumerMetricsStore) Metrics(m *ConsumerMetrics) {
 // ConsumerWithMetrics instance.
 type ConsumerAttributes struct {
 	// The number of writing goroutines
-	Concurrency int
+	Concurrency uint
 	// The number of records written each time
-	BatchSize int
+	BatchSize uint
 	// The maximum records per second per goroutine. 0 means unlimited.
-	RecordsPerSecond int
+	RecordsPerSecond uint
 	// The time period length for rolled up values.
 	// A value bigger than 0 means that client should feed this consumer
 	// store.NamedIterator instances that report summarised values for
@@ -276,7 +276,7 @@ type ConsumerAttributes struct {
 }
 
 // TotalRecordsPerSecond returns RecordsPerSecond * Concurrency
-func (c *ConsumerAttributes) TotalRecordsPerSecond() int {
+func (c *ConsumerAttributes) TotalRecordsPerSecond() uint {
 	return c.RecordsPerSecond * c.Concurrency
 }
 
@@ -353,29 +353,26 @@ func (b *ConsumerWithMetricsBuilder) AddHook(hook RecordWriteHooker) {
 }
 
 // SetRecordsPerSecond throttles writes. Default is 0 which means no
-// throttling. SetRecordsPerSecond panics if recordsPerSecond is negative.
+// throttling.
 func (b *ConsumerWithMetricsBuilder) SetRecordsPerSecond(
-	recordsPerSecond int) {
-	if recordsPerSecond < 0 {
-		panic("recordsPerSecond must be non negative")
-	}
+	recordsPerSecond uint) {
 	b.c.attributes.RecordsPerSecond = recordsPerSecond
 }
 
 // SetBufferSize sets how many values the consumer will buffer before
 // writing them out. The default is 1000. SetBufferSize panics if size < 1.
-func (b *ConsumerWithMetricsBuilder) SetBufferSize(size int) {
+func (b *ConsumerWithMetricsBuilder) SetBufferSize(size uint) {
 	if size < 1 {
-		panic("positive, non-zero size required.")
+		panic("non-zero size required.")
 	}
 	b.c.attributes.BatchSize = size
 }
 
 // SetConcurrency sets how many goroutines will write to the underlying
 // writer. Default is 1. SetConcurrency panics if concurrency < 1.
-func (b *ConsumerWithMetricsBuilder) SetConcurrency(concurrency int) {
+func (b *ConsumerWithMetricsBuilder) SetConcurrency(concurrency uint) {
 	if concurrency < 1 {
-		panic("positive, non-zero concurrency required.")
+		panic("non-zero concurrency required.")
 	}
 	b.c.attributes.Concurrency = concurrency
 }

--- a/pstore/config/api.go
+++ b/pstore/config/api.go
@@ -80,8 +80,8 @@ func Reset(configs ...Config) {
 // Decorator creates a decorated writer.
 type Decorator struct {
 	// Maximum reocrds to write per second. Optional.
-	// 0 or negative means no limit.
-	RecordsPerSecond int `yaml:"recordsPerSecond"`
+	// 0 means no limit.
+	RecordsPerSecond uint `yaml:"recordsPerSecond"`
 	// Metrics whose name matches DebugMetricRegex AND whose host matches
 	// DebugHostRegex are written to the debug file. Empty values in
 	// both of these fields means no debugging. An empty value in
@@ -103,11 +103,11 @@ type ConsumerConfig struct {
 	// The name of the consumer. Required.
 	Name string `yaml:"name"`
 	// The number of goroutines doing writing. Optional.
-	// A zero or negative value means 1.
-	Concurrency int `yaml:"concurrency"`
+	// A zero value means 1.
+	Concurrency uint `yaml:"concurrency"`
 	// The number of values written each time. Optional.
-	// A zero or negative value means 1000.
-	BatchSize int `yaml:"batchSize"`
+	// A zero value means 1000.
+	BatchSize uint `yaml:"batchSize"`
 	// The length of time for rolling up values when writing. Optional.
 	// Zero means write every value and do no rollup.
 	RollUpSpan time.Duration `yaml:"rollUpSpan"`

--- a/pstore/config/config_test.go
+++ b/pstore/config/config_test.go
@@ -103,12 +103,8 @@ func TestReadConfig(t *testing.T) {
     name: "minimal"
 - writer:
     someField: "another"
-  options:
-    recordsPerSecond: -235
   consumer:
-    concurrency: -2
-    name: "negative"
-    batchSize: -17
+    name: "zero"
     rollUpSpan: -2m
 `
 	consumerBuilders, err := consumerBuildersFromString(configFile)
@@ -138,7 +134,7 @@ func TestReadConfig(t *testing.T) {
 			BatchSize:   1000,
 		},
 		attributes)
-	assertValueEquals(t, "negative", consumers[2].Name())
+	assertValueEquals(t, "zero", consumers[2].Name())
 	consumers[2].Attributes(&attributes)
 	assertValueEquals(
 		t,

--- a/sources/api.go
+++ b/sources/api.go
@@ -8,7 +8,7 @@ import (
 // Connector connects to a particular type of source.
 // Connector implementations must be safe to use with multiple goroutines.
 type Connector interface {
-	Connect(host string, port int) (Poller, error)
+	Connect(host string, port uint) (Poller, error)
 	Name() string
 }
 

--- a/sources/snmpsource/snmpsource.go
+++ b/sources/snmpsource/snmpsource.go
@@ -11,7 +11,7 @@ func newConnector(community string) sources.Connector {
 	return connectorType(community)
 }
 
-func (c connectorType) Connect(host string, port int) (sources.Poller, error) {
+func (c connectorType) Connect(host string, port uint) (sources.Poller, error) {
 	return nil, errors.New("SNMP not supported.")
 }
 

--- a/sources/trisource/trisource.go
+++ b/sources/trisource/trisource.go
@@ -16,7 +16,7 @@ var (
 	kConnector = connectorType(0)
 )
 
-func (c connectorType) Connect(host string, port int) (sources.Poller, error) {
+func (c connectorType) Connect(host string, port uint) (sources.Poller, error) {
 	conn, err := rpc.DialHTTP(
 		"tcp",
 		fmt.Sprintf("%s:%d", host, port))

--- a/store/api.go
+++ b/store/api.go
@@ -371,9 +371,9 @@ type Store struct {
 // degree is the degree of the btrees (see github.com/Symantec/btree)
 func NewStore(
 	valueCount,
-	pageCount int,
+	pageCount uint,
 	inactiveThreshhold float64,
-	degree int) *Store {
+	degree uint) *Store {
 	return NewStoreBytesPerPage(
 		valueCount*kTsAndValueSize,
 		pageCount,
@@ -391,9 +391,9 @@ func NewStore(
 // degree is the degree of the btrees (see github.com/Symantec/btree)
 func NewStoreBytesPerPage(
 	bytesPerPage,
-	pageCount int,
+	pageCount uint,
 	inactiveThreshhold float64,
-	degree int) *Store {
+	degree uint) *Store {
 	return &Store{
 		byApplication: make(map[interface{}]*timeSeriesCollectionType),
 		supplier: newPageQueueType(
@@ -442,7 +442,7 @@ func (s *Store) RegisterEndpoint(endpointId interface{}) {
 func (s *Store) AddBatch(
 	endpointId interface{},
 	timestamp float64,
-	metricList metrics.List) (numAdded int, err error) {
+	metricList metrics.List) (numAdded uint, err error) {
 	return s.addBatch(endpointId, timestamp, metricList)
 }
 
@@ -591,9 +591,9 @@ func (s *Store) TimeLeft(name string) (seconds float64) {
 func (s *Store) NamedIteratorForEndpoint(
 	name string,
 	endpointId interface{},
-	maxFrames int) (
+	maxFrames uint) (
 	iterator NamedIterator, remainingValuesInSeconds float64) {
-	return s.namedIteratorForEndpoint(name, endpointId, maxFrames)
+	return s.namedIteratorForEndpoint(name, endpointId, int(maxFrames))
 }
 
 // NamedIteratorForEndpointRollUp works like NamedItgeratorForEndpoint except
@@ -647,11 +647,11 @@ func (s *Store) NamedIteratorForEndpointRollUp(
 	name string,
 	endpointId interface{},
 	dur time.Duration,
-	maxFrames int,
+	maxFrames uint,
 	strategy MetricGroupingStrategy) (
 	iterator NamedIterator, remainingValuesInSeconds float64) {
 	return s.namedIteratorForEndpointRollUp(
-		name, endpointId, dur, maxFrames, strategy)
+		name, endpointId, dur, int(maxFrames), strategy)
 }
 
 // LatestByEndpoint returns the latest records for each metric for a

--- a/store/btreepq/api.go
+++ b/store/btreepq/api.go
@@ -27,14 +27,14 @@ type Page interface {
 
 // PageQueueStats represents statistics for a PageQueue
 type PageQueueStats struct {
-	LowPriorityCount      int
-	HighPriorityCount     int
+	LowPriorityCount      uint
+	HighPriorityCount     uint
 	NextLowPrioritySeqNo  uint64
 	NextHighPrioritySeqNo uint64
 	EndSeqNo              uint64
 }
 
-func (s *PageQueueStats) TotalCount() int {
+func (s *PageQueueStats) TotalCount() uint {
 	return s.LowPriorityCount + s.HighPriorityCount
 }
 
@@ -59,7 +59,7 @@ type PageQueue struct {
 
 	// Number of pages that must be in high before the page queue ignores low
 	// when finding the next page.
-	threshhold int
+	threshhold uint
 
 	// The next available sequence number. This value increases monotonically.
 	nextSeqNo uint64
@@ -74,7 +74,7 @@ type PageQueue struct {
 func New(
 	pageCount,
 	threshhold,
-	degree int,
+	degree uint,
 	creater func() Page) *PageQueue {
 	if pageCount < 1 {
 		panic("pageCount must be at least 1")

--- a/store/btreepq/btreepq.go
+++ b/store/btreepq/btreepq.go
@@ -7,12 +7,12 @@ import (
 func _new(
 	pageCount,
 	threshhold,
-	degree int,
+	degree uint,
 	creater func() Page) *PageQueue {
 	fl := btree.NewFreeList(btree.DefaultFreeListSize)
-	high := btree.NewWithFreeList(degree, fl)
-	low := btree.NewWithFreeList(degree, fl)
-	for i := 0; i < pageCount; i++ {
+	high := btree.NewWithFreeList(int(degree), fl)
+	low := btree.NewWithFreeList(int(degree), fl)
+	for i := uint(0); i < pageCount; i++ {
 		page := creater()
 		page.SetSeqNo(uint64(i))
 		insert(high, page)
@@ -30,7 +30,7 @@ func _new(
 }
 
 func (p *PageQueue) popPage() Page {
-	if p.high.Len() >= p.threshhold {
+	if uint(p.high.Len()) >= p.threshhold {
 		return p.high.DeleteMin().(Page)
 	}
 	lowNext := first(p.low)
@@ -72,8 +72,8 @@ func (p *PageQueue) moveFromTo(pg Page, from, to *btree.BTree) {
 }
 
 func (p *PageQueue) _stats(stats *PageQueueStats) {
-	stats.HighPriorityCount = p.high.Len()
-	stats.LowPriorityCount = p.low.Len()
+	stats.HighPriorityCount = uint(p.high.Len())
+	stats.LowPriorityCount = uint(p.low.Len())
 	stats.EndSeqNo = p.nextSeqNo
 	lowNext := first(p.low)
 	highNext := first(p.high)

--- a/store/btreepq/btreepq_test.go
+++ b/store/btreepq/btreepq_test.go
@@ -26,7 +26,7 @@ func (p *pageForTesting) Less(than btree.Item) bool {
 func TestZeroThreshhold(t *testing.T) {
 	var pages [4]btreepq.Page
 	queue := btreepq.New(
-		len(pages),
+		uint(len(pages)),
 		0,
 		10,
 		func() btreepq.Page {
@@ -41,7 +41,7 @@ func TestZeroThreshhold(t *testing.T) {
 func TestRemovePages(t *testing.T) {
 	var pages [8]btreepq.Page
 	queue := btreepq.New(
-		len(pages),
+		uint(len(pages)),
 		2,
 		10,
 		func() btreepq.Page {
@@ -86,7 +86,7 @@ func TestRemovePages(t *testing.T) {
 func TestAPI(t *testing.T) {
 	var pages [8]btreepq.Page
 	queue := btreepq.New(
-		len(pages),
+		uint(len(pages)),
 		2,
 		10,
 		func() btreepq.Page {

--- a/store/pagequeue.go
+++ b/store/pagequeue.go
@@ -11,21 +11,24 @@ import (
 // This file contains all the code related to the page queue.
 
 type pageQueueType struct {
-	valueCountPerPage  int
+	valueCountPerPage  uint
 	inactiveThreshhold float64
-	degree             int
+	degree             uint
 	lock               sync.Mutex
 	pq                 *btreepq.PageQueue
 }
 
 func newPageQueueType(
-	bytesPerPage int,
-	pageCount int,
+	bytesPerPage uint,
+	pageCount uint,
 	inactiveThreshhold float64,
-	degree int) *pageQueueType {
+	degree uint) *pageQueueType {
+	if inactiveThreshhold < 0.0 {
+		panic("inactiveThreshhold cannot be negative")
+	}
 	pages := btreepq.New(
 		pageCount,
-		int(float64(pageCount)*inactiveThreshhold),
+		uint(float64(pageCount)*inactiveThreshhold),
 		degree,
 		func() btreepq.Page {
 			return newPageWithMetaDataType(bytesPerPage)
@@ -37,7 +40,7 @@ func newPageQueueType(
 		pq:                 pages}
 }
 
-func (s *pageQueueType) MaxValuesPerPage() int {
+func (s *pageQueueType) MaxValuesPerPage() uint {
 	return s.valueCountPerPage
 }
 

--- a/store/pages.go
+++ b/store/pages.go
@@ -13,9 +13,9 @@ var (
 	kTsAndValueSize = tsAndValueSize()
 )
 
-func tsAndValueSize() int {
+func tsAndValueSize() uint {
 	var p pageType
-	return int(reflect.TypeOf(p).Elem().Size())
+	return uint(reflect.TypeOf(p).Elem().Size())
 }
 
 // basicPageType is the interface that all page data must implement
@@ -135,7 +135,7 @@ type pageWithMetaDataType struct {
 	values []tsValueType
 }
 
-func newPageWithMetaDataType(bytesPerPage int) *pageWithMetaDataType {
+func newPageWithMetaDataType(bytesPerPage uint) *pageWithMetaDataType {
 	return &pageWithMetaDataType{
 		values: make(pageType, 0, bytesPerPage/kTsAndValueSize)}
 }

--- a/store/seriescollection.go
+++ b/store/seriescollection.go
@@ -506,17 +506,17 @@ func (c *timeSeriesCollectionType) MarkInactive(
 func (c *timeSeriesCollectionType) AddBatch(
 	timestamp float64,
 	mlist metrics.List,
-	supplier *pageQueueType) (result int, err error) {
+	supplier *pageQueueType) (result uint, err error) {
 	c.statusChangeLock.Lock()
 	defer c.statusChangeLock.Unlock()
 	fetched, newOnes, notFetched, tsFetched, newTs, tsNotFetched, err := c.LookupBatch(timestamp, mlist)
 	if err != nil {
 		return
 	}
-	result = c.updateTimeStampSeriesAndTimeSeries(
+	result = uint(c.updateTimeStampSeriesAndTimeSeries(
 		newOnes, fetched, notFetched,
 		newTs, tsFetched, tsNotFetched,
-		supplier)
+		supplier))
 	return
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -59,7 +59,7 @@ func (s *Store) shallowCopy() *Store {
 func (s *Store) addBatch(
 	endpointId interface{},
 	timestamp float64,
-	mlist metrics.List) (int, error) {
+	mlist metrics.List) (uint, error) {
 	return s.byApplication[endpointId].AddBatch(
 		timestamp, mlist, s.supplier)
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -188,9 +188,9 @@ func newStore(
 	t *testing.T,
 	testName string,
 	valueCount,
-	pageCount int,
+	pageCount uint,
 	inactiveThreshhold float64,
-	degree int) *store.Store {
+	degree uint) *store.Store {
 	result := store.NewStore(
 		valueCount, pageCount, inactiveThreshhold, degree)
 	dirSpec, err := tricorder.RegisterDirectory("/" + testName)
@@ -3146,7 +3146,7 @@ func addBatch(
 	endpointId *scotty.Endpoint,
 	ts float64,
 	m metrics.List,
-	count int) {
+	count uint) {
 	out, err := astore.AddBatch(endpointId, ts, m)
 	if err != nil {
 		t.Errorf("Expected AddBatch to succeed")


### PR DESCRIPTION
This is my first try at int to uint conversion. 
- Interfaces with a Len() method I kept as Len() int since the builtin len() returns an int.
- Number of pages in scotty is a uint because the underlying btree library we use to keep up with pages uses int to represent btree size.
- uint for writes per second, I don't think we will ever do more than 4 billion writes per second.
- Page size in bytes also a uint as pages will be comparable size to hardware pages.
- Writing threads count also a uint. Don't think we will need 4B threads to write metrics to persistent store.
- Number of values to write in a batch also uint
