### PR TITLE
Get rid of config.Decorator

### DIFF
--- a/pstore/config/api.go
+++ b/pstore/config/api.go
@@ -77,8 +77,19 @@ func Reset(configs ...Config) {
 	}
 }
 
-// Decorator creates a decorated writer.
-type Decorator struct {
+// ConsumerConfig creates a consumer builder
+type ConsumerConfig struct {
+	// The name of the consumer. Required.
+	Name string `yaml:"name"`
+	// The number of goroutines doing writing. Optional.
+	// A zero value means 1.
+	Concurrency uint `yaml:"concurrency"`
+	// The number of values written each time. Optional.
+	// A zero value means 1000.
+	BatchSize uint `yaml:"batchSize"`
+	// The length of time for rolling up values when writing. Optional.
+	// Zero means write every value and do no rollup.
+	RollUpSpan time.Duration `yaml:"rollUpSpan"`
 	// Maximum reocrds to write per second. Optional.
 	// 0 means no limit.
 	RecordsPerSecond uint `yaml:"recordsPerSecond"`
@@ -94,31 +105,11 @@ type Decorator struct {
 	DebugFilePath string `yaml:"debugFilePath"`
 }
 
-func (d *Decorator) Reset() {
-	*d = Decorator{}
-}
-
-// ConsumerConfig creates a consumer builder
-type ConsumerConfig struct {
-	// The name of the consumer. Required.
-	Name string `yaml:"name"`
-	// The number of goroutines doing writing. Optional.
-	// A zero value means 1.
-	Concurrency uint `yaml:"concurrency"`
-	// The number of values written each time. Optional.
-	// A zero value means 1000.
-	BatchSize uint `yaml:"batchSize"`
-	// The length of time for rolling up values when writing. Optional.
-	// Zero means write every value and do no rollup.
-	RollUpSpan time.Duration `yaml:"rollUpSpan"`
-}
-
 // NewConsumerBuilder creates a new consumer builder using the given
 // WriterFactory.
-func (c *ConsumerConfig) NewConsumerBuilder(
-	wf WriterFactory, d *Decorator) (
+func (c *ConsumerConfig) NewConsumerBuilder(wf WriterFactory) (
 	*pstore.ConsumerWithMetricsBuilder, error) {
-	return c.newConsumerBuilder(wf, *d)
+	return c.newConsumerBuilder(wf)
 }
 
 func (c *ConsumerConfig) Reset() {

--- a/pstore/config/config.go
+++ b/pstore/config/config.go
@@ -118,8 +118,7 @@ func newWriteHooker(debugMetricRegex, debugHostRegex, debugFilePath string) (
 	return &hookWriter{wrapped: filterWriter}, nil
 }
 
-func (c ConsumerConfig) newConsumerBuilder(
-	wf WriterFactory, d Decorator) (
+func (c ConsumerConfig) newConsumerBuilder(wf WriterFactory) (
 	result *pstore.ConsumerWithMetricsBuilder, err error) {
 	if c.Name == "" {
 		return nil, errors.New("Name field is required.")
@@ -138,13 +137,13 @@ func (c ConsumerConfig) newConsumerBuilder(
 		return
 	}
 	builder := pstore.NewConsumerWithMetricsBuilder(writer)
-	if d.RecordsPerSecond > 0 {
-		builder.SetRecordsPerSecond(d.RecordsPerSecond)
+	if c.RecordsPerSecond > 0 {
+		builder.SetRecordsPerSecond(c.RecordsPerSecond)
 	}
-	if d.DebugMetricRegex != "" || d.DebugHostRegex != "" {
+	if c.DebugMetricRegex != "" || c.DebugHostRegex != "" {
 		var hook pstore.RecordWriteHooker
 		hook, err = newWriteHooker(
-			d.DebugMetricRegex, d.DebugHostRegex, d.DebugFilePath)
+			c.DebugMetricRegex, c.DebugHostRegex, c.DebugFilePath)
 		if err != nil {
 			return
 		}

--- a/pstore/config/config_test.go
+++ b/pstore/config/config_test.go
@@ -34,17 +34,16 @@ func (c *configType) Reset() {
 
 type configPlus struct {
 	Writer   configType            `yaml:"writer"`
-	Options  config.Decorator      `yaml:"options"`
 	Consumer config.ConsumerConfig `yaml:"consumer"`
 }
 
 func (c *configPlus) NewConsumerBuilder() (
 	*pstore.ConsumerWithMetricsBuilder, error) {
-	return c.Consumer.NewConsumerBuilder(&c.Writer, &c.Options)
+	return c.Consumer.NewConsumerBuilder(&c.Writer)
 }
 
 func (c *configPlus) Reset() {
-	config.Reset(&c.Writer, &c.Options, &c.Consumer)
+	config.Reset(&c.Writer, &c.Consumer)
 }
 
 type configList []configPlus
@@ -90,9 +89,8 @@ func TestReadConfig(t *testing.T) {
 # a comment
 - writer:
     someField: "some value"
-  options:
-    recordsPerSecond: 124
   consumer:
+    recordsPerSecond: 124
     name: "some name"
     concurrency: 7
     batchSize: 730
@@ -150,21 +148,19 @@ func TestReadConfigDupName(t *testing.T) {
 # a comment
 - writer:
     someField: "some value"
-  options:
-    recordsPerSecond: 124
   consumer:
+    recordsPerSecond: 124
     name: "some name"
     concurrency: 7
     batchSize: 730
 - writer:
-    someField: "hello"
+	someField: "hello"
   consumer:
     name: "minimal"
 - writer:
-    someField: "another"
-  options:
-    recordsPerSecond: -235
+	someField: "another"
   consumer:
+    recordsPerSecond: -235
     concurrency: -2
     # dup name
     name: "minimal"
@@ -181,9 +177,8 @@ func TestConfigMissingName(t *testing.T) {
 # a comment
 - writer:
     someField: "some value"
-  options:
-    recordsPerSecond: 124
   consumer:
+    recordsPerSecond: 124
     name: "some name"
     concurrency: 7
     batchSize: 730
@@ -192,10 +187,9 @@ func TestConfigMissingName(t *testing.T) {
   consumer:
     name: "minimal"
 - writer:
-    someField: "another"
-  options:
-    recordsPerSecond: -235
+	someField: "another"
   consumer:
+    recordsPerSecond: -235
     concurrency: -2
     # missing name
     batchSize: -17

--- a/pstore/influx/api.go
+++ b/pstore/influx/api.go
@@ -56,17 +56,16 @@ func (c *Config) Reset() {
 // ConfigPlus implements config.Config and config.WriterFactory
 type ConfigPlus struct {
 	Writer   Config                `yaml:"writer"`
-	Options  config.Decorator      `yaml:"options"`
 	Consumer config.ConsumerConfig `yaml:"consumer"`
 }
 
 func (c *ConfigPlus) NewConsumerBuilder() (
 	*pstore.ConsumerWithMetricsBuilder, error) {
-	return c.Consumer.NewConsumerBuilder(&c.Writer, &c.Options)
+	return c.Consumer.NewConsumerBuilder(&c.Writer)
 }
 
 func (c *ConfigPlus) Reset() {
-	config.Reset(&c.Writer, &c.Options, &c.Consumer)
+	config.Reset(&c.Writer, &c.Consumer)
 }
 
 // ConfigList represents a list of entire influx db configurations.

--- a/pstore/influx/influx_test.go
+++ b/pstore/influx/influx_test.go
@@ -35,3 +35,52 @@ retentionPolicy: myPolicy
 		t.Errorf("Expected %v, got %v", expected, aconfig)
 	}
 }
+
+func TestInfluxConfigPlus(t *testing.T) {
+	configFile := `
+writer:
+  database: aDatabase
+  hostAndPort: localhost:8085
+  username: foo
+  password: apassword
+  precision: ms
+  writeConsistency: one
+  retentionPolicy: myPolicy
+consumer:
+  recordsPerSecond: 20
+  debugMetricRegex: foo
+  debugHostRegex: bar
+  debugFilePath: hello
+  name: r15i11
+  concurrency: 2
+  batchSize: 700
+`
+	buffer := bytes.NewBuffer(([]byte)(configFile))
+	var aconfig ConfigPlus
+	if err := config.Read(buffer, &aconfig); err != nil {
+		t.Fatal(err)
+	}
+	expected := ConfigPlus{
+		Writer: Config{
+			Database:         "aDatabase",
+			HostAndPort:      "localhost:8085",
+			UserName:         "foo",
+			Password:         "apassword",
+			RetentionPolicy:  "myPolicy",
+			WriteConsistency: "one",
+			Precision:        "ms",
+		},
+		Consumer: config.ConsumerConfig{
+			Name:             "r15i11",
+			Concurrency:      2,
+			BatchSize:        700,
+			DebugMetricRegex: "foo",
+			DebugHostRegex:   "bar",
+			RecordsPerSecond: 20,
+			DebugFilePath:    "hello",
+		},
+	}
+	if !reflect.DeepEqual(expected, aconfig) {
+		t.Errorf("Expected %v, got %v", expected, aconfig)
+	}
+}

--- a/pstore/kafka/api.go
+++ b/pstore/kafka/api.go
@@ -76,17 +76,16 @@ func (c *Config) Reset() {
 // ConfigPlus implements config.Config and config.WriterFactory
 type ConfigPlus struct {
 	Writer   Config                `yaml:"writer"`
-	Options  config.Decorator      `yaml:"options"`
 	Consumer config.ConsumerConfig `yaml:"consumer"`
 }
 
 func (c *ConfigPlus) NewConsumerBuilder() (
 	*pstore.ConsumerWithMetricsBuilder, error) {
-	return c.Consumer.NewConsumerBuilder(&c.Writer, &c.Options)
+	return c.Consumer.NewConsumerBuilder(&c.Writer)
 }
 
 func (c *ConfigPlus) Reset() {
-	config.Reset(&c.Writer, &c.Options, &c.Consumer)
+	config.Reset(&c.Writer, &c.Consumer)
 }
 
 // ConfigList represents a list of entire kafka configurations.

--- a/pstore/kafka/kafka_test.go
+++ b/pstore/kafka/kafka_test.go
@@ -43,6 +43,57 @@ someUnusedField: true
 	}
 }
 
+func TestKafkaConfigPlus(t *testing.T) {
+	configFile := `
+# A comment
+writer:
+  endpoints:
+    - 10.0.0.1:9092
+    - 10.0.1.3:9092
+    - 10.0.1.6:9092
+  topic: someTopic
+  apiKey: someApiKey
+  tenantId: someTenantId
+  clientId: someClientId
+  someUnusedField: true
+consumer:
+  recordsPerSecond: 20
+  debugMetricRegex: foo
+  debugHostRegex: bar
+  debugFilePath: hello
+  name: r15i11
+  concurrency: 2
+  batchSize: 700
+`
+	buffer := bytes.NewBuffer(([]byte)(configFile))
+	var aconfig ConfigPlus
+	if err := config.Read(buffer, &aconfig); err != nil {
+		t.Fatal(err)
+	}
+	expected := ConfigPlus{
+		Writer: Config{
+			ApiKey:   "someApiKey",
+			TenantId: "someTenantId",
+			ClientId: "someClientId",
+			Topic:    "someTopic",
+			Endpoints: []string{
+				"10.0.0.1:9092", "10.0.1.3:9092", "10.0.1.6:9092"},
+		},
+		Consumer: config.ConsumerConfig{
+			Name:             "r15i11",
+			Concurrency:      2,
+			BatchSize:        700,
+			DebugMetricRegex: "foo",
+			DebugHostRegex:   "bar",
+			RecordsPerSecond: 20,
+			DebugFilePath:    "hello",
+		},
+	}
+	if !reflect.DeepEqual(expected, aconfig) {
+		t.Errorf("Expected %v, got %v", expected, aconfig)
+	}
+}
+
 func TestSerializeInt(t *testing.T) {
 	ser := recordSerializerType{TenantId: "myTenantId", ApiKey: "myApiKey"}
 	bytes, err := ser.Serialize(

--- a/pstore/tsdb/api.go
+++ b/pstore/tsdb/api.go
@@ -47,17 +47,16 @@ func (c *Config) Reset() {
 // ConfigPlus implements config.Config and config.WriterFactory
 type ConfigPlus struct {
 	Writer   Config                `yaml:"writer"`
-	Options  config.Decorator      `yaml:"options"`
 	Consumer config.ConsumerConfig `yaml:"consumer"`
 }
 
 func (c *ConfigPlus) NewConsumerBuilder() (
 	*pstore.ConsumerWithMetricsBuilder, error) {
-	return c.Consumer.NewConsumerBuilder(&c.Writer, &c.Options)
+	return c.Consumer.NewConsumerBuilder(&c.Writer)
 }
 
 func (c *ConfigPlus) Reset() {
-	config.Reset(&c.Writer, &c.Options, &c.Consumer)
+	config.Reset(&c.Writer, &c.Consumer)
 }
 
 // ConfigList represents a list of entire tsdb configurations.

--- a/pstore/tsdb/tsdb_test.go
+++ b/pstore/tsdb/tsdb_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestInfluxConfig(t *testing.T) {
+func TestTsdbConfig(t *testing.T) {
 	configFile := `
 hostAndPort: localhost:8085
 timeout: 35s
@@ -21,6 +21,46 @@ timeout: 35s
 	expected := Config{
 		HostAndPort: "localhost:8085",
 		Timeout:     35 * time.Second,
+	}
+	if !reflect.DeepEqual(expected, aconfig) {
+		t.Errorf("Expected %v, got %v", expected, aconfig)
+	}
+}
+
+func TestTsdbConfigPlus(t *testing.T) {
+	configFile := `
+# A comment
+writer:
+  hostAndPort: localhost:8084
+  timeout: 37s
+consumer:
+  recordsPerSecond: 20
+  debugMetricRegex: foo
+  debugHostRegex: bar
+  debugFilePath: hello
+  name: r15i11
+  concurrency: 2
+  batchSize: 700
+`
+	buffer := bytes.NewBuffer(([]byte)(configFile))
+	var aconfig ConfigPlus
+	if err := config.Read(buffer, &aconfig); err != nil {
+		t.Fatal(err)
+	}
+	expected := ConfigPlus{
+		Writer: Config{
+			HostAndPort: "localhost:8084",
+			Timeout:     37 * time.Second,
+		},
+		Consumer: config.ConsumerConfig{
+			Name:             "r15i11",
+			Concurrency:      2,
+			BatchSize:        700,
+			DebugMetricRegex: "foo",
+			DebugHostRegex:   "bar",
+			RecordsPerSecond: 20,
+			DebugFilePath:    "hello",
+		},
 	}
 	if !reflect.DeepEqual(expected, aconfig) {
 		t.Errorf("Expected %v, got %v", expected, aconfig)


### PR DESCRIPTION
This is the first of 3 PR's to clean up persistent store scotty config files.

Background:

Currently, if I misspell a field name in a pstore config file, scotty silently skips over the misspelled field. This behavior is not ideal. For instance, if I am including a kafka API key in a config file, and I misspell the apiKey field name, scotty will fail to write to kafka leaving me to guessing whether it is the network, a bad API key, or a misspelled field name in the config file causing the failure. If scotty can determine that a field name is misspelled, it should fail fast so that the problem can be fixed.

The second problem with the pstore config files is that they are more complicated than they need to be.

The solution:

To solve the problem of misspelled fields in pstore config files, I introduce strict parsing. If a field in a config file does not match any field in the corresponding go structure, strict parsing throws an error. If a go struct requires strict parsing, it needs to provide an UnmarshalYAML method that delegates to the general purpose config.StrictUnmarshalYAML() method.  To prevent infinite recursion when unmarshaling, each go struct being unmarshalled has a mirror type that is missing the UnmarshalYAML() method.
This can be done in the following way: type noUnmarshalYAMLType OriginalType

To make the config files less complicated, I have gotten rid of the config.Decorator structure. While this type did serve a purpose at one time, it has no real methods now. It has become a lazy type. Now each persistent store contains two parts: the writer part and the consumer part. The writer part contains configurations specific to the pstore implementation. For instance influxdb requires different fields in the writer part than kafka. The consumer part contains fields common to all pstore backends such as the amount of concurrency or the time span to use when rolling up metrics.

This PR:

This PR gets rid of config.Decorator

Future PRs:

The next PR in this pipeline introduces strict parsing for pstore config files.
The last PR exposes any errors initializing the pstore as a metric. Alternatively, we could emit the error to the log file or both.
