### PR TITLE
Add travis.yml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: go
+


### PR DESCRIPTION
This is the .travis.yml file for scotty. This tells Travis CI that scotty is a plain old go project following the conventional go directory structure. Once Travis CI has access to the main scotty repo, it will do continuous builds on each new commit from here on out. If the build breaks in any branch including the master branch, Travis CI adds a conspicuous red X to the offending revision in github.
