### PR TITLE
Small bug fixes to Scotty / Grafana integration

### DIFF
--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -1490,7 +1490,8 @@ func main() {
 	http.Handle(
 		"/showAllApps",
 		gzipHandler{&showallapps.Handler{
-			AS: applicationStats,
+			AS:             applicationStats,
+			CollectionFreq: *fCollectionFrequency,
 		}})
 	http.Handle(
 		"/api/hosts/",

--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -1510,7 +1510,8 @@ func main() {
 		"/api/query",
 		tsdbexec.NewHandler(
 			func(r *tsdbjson.QueryRequest) ([]tsdbjson.TimeSeries, error) {
-				return tsdbexec.Query(r, applicationStats)
+				return tsdbexec.Query(
+					r, applicationStats, *fCollectionFrequency)
 			}))
 	tsdbServeMux.Handle(
 		"/api/suggest",

--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -560,9 +560,11 @@ func (l *loggerType) reportNewNamesForSuggest(
 	for i := 0; i < length; i++ {
 		var value metrics.Value
 		list.Index(i, &value)
-		if !l.NamesSentToSuggest[value.Path] {
-			l.MetricNameAdder.Add(value.Path)
-			l.NamesSentToSuggest[value.Path] = true
+		if types.FromGoValue(value.Value).CanToFromFloat() {
+			if !l.NamesSentToSuggest[value.Path] {
+				l.MetricNameAdder.Add(value.Path)
+				l.NamesSentToSuggest[value.Path] = true
+			}
 		}
 	}
 }

--- a/tsdbexec/api.go
+++ b/tsdbexec/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Symantec/scotty/tsdbjson"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 var (
@@ -35,9 +36,10 @@ func Suggest(
 // Query corresponds to the /api/query TSDB API call.
 func Query(
 	request *tsdbjson.QueryRequest,
-	endpoints *datastructs.ApplicationStatuses) (
+	endpoints *datastructs.ApplicationStatuses,
+	minDownSampleTime time.Duration) (
 	result []tsdbjson.TimeSeries, err error) {
-	return query(request, endpoints)
+	return query(request, endpoints, minDownSampleTime)
 }
 
 // NewHandler creates a handler to service a particular TSDB API endpoint.


### PR DESCRIPTION
Reinstating this pull request. Travis CI is reporting false build failures because I don't have it set up correctly.

This is a collection of three small commits to fix minor bugs in scotty /grafana integration.
1.  Force Downsample duration to be at least collection duration. This gets rid of unnecessary noise in the graphs.
2. Suggest only float type metrics for now since we can't graph string, list, or distribution metrics in grafana right now.
3. Since scotty now keeps distributions, showing the last hour of metrics for a given endpoint crashes firefox as the JSON is too big. Instead, I make default history be one collection duration so that by default we show only the latest readings for an endpoint.
