### PR TITLE
Set up symlink from Symantec to actual git user for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: go
+before_install:
+- ./add_sym_links.sh
 

--- a/add_sym_links.sh
+++ b/add_sym_links.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+test -e ../../Symantec || ln -s $(basename $(dirname $(pwd))) ../../Symantec
+


### PR DESCRIPTION
This fixes the Travis CI false build failures.

What this PR does is instructs Travis CI to run the ./add_sym_links.sh script before doing the build. add_sym_links.sh adds a symlink from Symantec to the current git user which will be me. In case you are merging into Symantec, the script will do nothing as it checks for the presence of a Symantec directory before building the sym link. 

I tried this out on the pull request that triggered false build failures and now that same pull request is green.
