### PR TITLE
Travis CI to correctly build scotty from forked repository.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,10 @@
 language: go
+before_install:
+- REPO_NAME=$(basename $PWD)
+- GITHUB_PATH=$(dirname $(dirname $PWD))
+- SYMANTEC_PROJECT_DIR=${GITHUB_PATH}/Symantec/${REPO_NAME}
+- mkdir -p ${SYMANTEC_PROJECT_DIR}
+- rsync -az ${TRAVIS_BUILD_DIR}/ ${SYMANTEC_PROJECT_DIR}/
+- export TRAVIS_BUILD_DIR=${SYMANTEC_PROJECT_DIR}
+- cd ${SYMANTEC_PROJECT_DIR}
 


### PR DESCRIPTION
This is arguably a cleaner way to make travis CI work with forked repos.

The advantage of this method is that this travis.yml file can be copied verbatim into any Symantec project and travis will build any forked repos from that project correctly. Moreover, as written, the travis.yml file is resilient to any directory structure changes the Travis CI team might make.
