### PR TITLE
Aggregator API to support custom methods for downsampling and aggregation.

### DIFF
--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Symantec/scotty/store"
 	"github.com/Symantec/scotty/suggest"
 	"github.com/Symantec/scotty/sysmemory"
+	"github.com/Symantec/scotty/tsdb/aggregators"
 	"github.com/Symantec/scotty/tsdbexec"
 	"github.com/Symantec/scotty/tsdbjson"
 	"github.com/Symantec/tricorder/go/tricorder"
@@ -1533,7 +1534,7 @@ func main() {
 		"/api/aggregators",
 		tsdbexec.NewHandler(
 			func(req url.Values) ([]string, error) {
-				return []string{"avg"}, nil
+				return aggregators.Names(), nil
 			},
 		))
 	tsdbServeMux.Handle(

--- a/tsdb/aggregators/aggregator.go
+++ b/tsdb/aggregators/aggregator.go
@@ -1,0 +1,111 @@
+package aggregators
+
+import (
+	"github.com/Symantec/scotty/tsdb"
+)
+
+// updaterType instances update aggregated values with values from downsampled
+// time series. The implementation used depends on both the aggregation
+// method and the fill policy.
+//
+// Generally, these instances CANNOT be used with multiple
+// goroutines
+type updaterType interface {
+	// Update updates aggregatorToBeUpdated with the values in
+	// downsampledTimeSeries.
+	Update(
+		downsampledTimeSeries getByIndexType,
+		aggregatorToBeUpdated adderType)
+}
+
+// getByIndexType instances can retrieve a value by index. Each index
+// represents some uniform time slice. The larger the index, the more
+// recent the time slice.
+type getByIndexType interface {
+	Len() int
+	// Get returns false for second value if value is missing.
+	Get(index int) (float64, bool)
+}
+
+type adderType interface {
+	// Add adds a new value at index, which represents some time slice
+	// The aggregation method such as sum, avg, max, etc. dictates how
+	// Add adds values.
+	Add(index int, value float64)
+}
+
+type aggregatorListType interface {
+	getByIndexType
+	adderType
+	// Clear resets this instance just as if no values have been
+	// added to it.
+	Clear()
+}
+
+// downSampleType is the tsdb.Aggregator implementation
+type downSampleType struct {
+	// aggregators stores the result of aggregating all the time series
+	aggregators aggregatorListType
+	// downAgg stores the current downsampled time series
+	downAgg aggregatorListType
+	// updater updates aggregators with the current downsampled time series
+	// as dictated by the downsample aggregation method and the fill policy
+	updater updaterType
+	// downSamplePolicy understands how to convert between time slices and
+	// indexes.
+	downSamplePolicy downSamplePolicyType
+}
+
+func _new(
+	start, end float64,
+	agg *Aggregator,
+	downSample float64,
+	downAgg *Aggregator,
+	fillPolicy FillPolicy) tsdb.Aggregator {
+	if end < start {
+		panic("end cannot be less than start")
+	}
+	result := &downSampleType{
+		downSamplePolicy: newDownSamplePolicyType(start, downSample),
+	}
+	length := result.downSamplePolicy.IndexOf(end) + 1
+	result.aggregators = agg.aggListCreater(length)
+	result.downAgg = downAgg.aggListCreater(length)
+	result.updater = downAgg.updaterCreater.Get(length, fillPolicy)
+	return result
+
+}
+
+func (d *downSampleType) Add(values tsdb.TimeSeries) {
+	valueLen := len(values)
+	// Process incoming time series one time slice at a time
+	for startIdx, endIdx := 0, 0; startIdx < valueLen; startIdx = endIdx {
+		endIdx = d.downSamplePolicy.NextSample(values, startIdx)
+		downSampledIdx := d.downSamplePolicy.IndexOf(values[startIdx].Ts)
+		// Add values in current time slice to d.downAgg one at a time.
+		for i := startIdx; i < endIdx; i++ {
+			d.downAgg.Add(downSampledIdx, values[i].Value)
+		}
+	}
+	// Update d.aggregators with current downsampled time series
+	d.updater.Update(d.downAgg, d.aggregators)
+	// finally clear current downsampled time series so that it is ready to
+	// use the next time.
+	d.downAgg.Clear()
+}
+
+func (d *downSampleType) Aggregate() (result tsdb.TimeSeries) {
+	aggLen := d.aggregators.Len()
+	// Convert aggregators field to the aggregated time series with the help
+	// of the downSamplePolicy field.
+	for i := 0; i < aggLen; i++ {
+		value, ok := d.aggregators.Get(i)
+		if ok {
+			result = append(result, tsdb.TsValue{
+				Ts:    d.downSamplePolicy.TSOf(i),
+				Value: value,
+			})
+		}
+	}
+	return
+}

--- a/tsdb/aggregators/aggregator_test.go
+++ b/tsdb/aggregators/aggregator_test.go
@@ -1,0 +1,248 @@
+package aggregators_test
+
+import (
+	"github.com/Symantec/scotty/tsdb"
+	"github.com/Symantec/scotty/tsdb/aggregators"
+	"reflect"
+	"testing"
+)
+
+func TestAverage(t *testing.T) {
+	aggregator := aggregators.New(
+		1000.0,
+		2000.0,
+		aggregators.Avg,
+		200.0,
+		aggregators.Avg,
+		aggregators.None)
+	aggregator.Add(tsdb.TimeSeries{
+		{1000.0, 42.0}, {1030.0, 54.0}, {1199.999, 49.5},
+		{1401.0, 20.0}, {1599.0, 30.0},
+		{1836.0, 98.0}})
+	aggregator.Add(tsdb.TimeSeries{
+		{1500.0, 1025.0},
+		{1600.0, 99.0},
+		{1800.0, 198.0}, {1801.0, 202.0}, {1999.1, 200.0}})
+	aggregator.Add(tsdb.TimeSeries{
+		{1400.0, 1975.0},
+		{1450.0, 2000.0},
+		{1599.0, 2025.0},
+		{1599.1, 2050.0},
+		{1599.2, 2075.0}})
+	aggregator.Add(nil)
+	aggregated := aggregator.Aggregate()
+	expected := tsdb.TimeSeries{
+		{1000.0, 48.5},
+		{1400.0, 1025.0},
+		{1600.0, 99.0},
+		{1800.0, 149.0}}
+	assertValueDeepEqual(t, expected, aggregated)
+}
+
+func TestAverageZero(t *testing.T) {
+	aggregator := aggregators.New(
+		1000.0,
+		2000.0,
+		aggregators.Avg,
+		200.0,
+		aggregators.Avg,
+		aggregators.Zero)
+	aggregator.Add(tsdb.TimeSeries{
+		{1000.0, 42.0}, {1030.0, 54.0}, {1199.999, 49.5},
+		{1401.0, 20.0}, {1599.0, 30.0},
+		{1836.0, 98.0}})
+	aggregator.Add(tsdb.TimeSeries{
+		{1500.0, 1025.0},
+		{1600.0, 99.0},
+		{1800.0, 198.0}, {1801.0, 202.0}, {1999.1, 200.0}})
+	aggregator.Add(tsdb.TimeSeries{
+		{1400.0, 1975.0},
+		{1450.0, 2000.0},
+		{1599.0, 2025.0},
+		{1599.1, 2050.0},
+		{1599.2, 2075.0}})
+	// Counts as all zeros
+	aggregator.Add(nil)
+	aggregated := aggregator.Aggregate()
+	expected := tsdb.TimeSeries{
+		{1000.0, 12.125},
+		{1200.0, 0.0},
+		{1400.0, 768.75},
+		{1600.0, 24.75},
+		{1800.0, 74.5},
+		{2000.0, 0.0}}
+	assertValueDeepEqual(t, expected, aggregated)
+}
+
+func TestAverageMax(t *testing.T) {
+	aggregator := aggregators.New(
+		1000.0,
+		2000.0,
+		aggregators.Avg,
+		200.0,
+		aggregators.Max,
+		aggregators.None)
+	aggregator.Add(tsdb.TimeSeries{
+		{1000.0, 42.0}, {1030.0, 54.0}, {1199.999, 49.5},
+		{1401.0, 20.0}, {1599.0, 30.5},
+		{1836.0, 98.0}})
+	aggregator.Add(tsdb.TimeSeries{
+		{1500.0, 1025.0},
+		{1600.0, 99.0},
+		{1800.0, 198.0}, {1801.0, 202.0}, {1999.1, 200.0}})
+	aggregator.Add(tsdb.TimeSeries{
+		{1400.0, 1975.0},
+		{1450.0, 2000.0},
+		{1599.0, 2025.0},
+		{1599.1, 2050.0},
+		{1599.2, 2075.0}})
+	aggregator.Add(nil)
+	aggregated := aggregator.Aggregate()
+	expected := tsdb.TimeSeries{
+		{1000.0, 54.0},
+		{1400.0, 1043.5},
+		{1600.0, 99.0},
+		{1800.0, 150.0}}
+	assertValueDeepEqual(t, expected, aggregated)
+}
+
+func TestMaxAverage(t *testing.T) {
+	aggregator := aggregators.New(
+		1000.0,
+		2000.0,
+		aggregators.Max,
+		200.0,
+		aggregators.Avg,
+		aggregators.None)
+	aggregator.Add(tsdb.TimeSeries{
+		{1000.0, 42.0}, {1030.0, 54.0}, {1199.999, 49.5},
+		{1401.0, 20.0}, {1599.0, 30.0},
+		{1836.0, 98.0}})
+	aggregator.Add(tsdb.TimeSeries{
+		{1500.0, 1025.0},
+		{1600.0, 99.0},
+		{1800.0, 198.0}, {1801.0, 202.0}, {1999.1, 200.0}})
+	aggregator.Add(tsdb.TimeSeries{
+		{1400.0, 1975.0},
+		{1450.0, 2000.0},
+		{1599.0, 2025.0},
+		{1599.1, 2050.0},
+		{1599.2, 2075.0}})
+	aggregator.Add(nil)
+	aggregated := aggregator.Aggregate()
+	expected := tsdb.TimeSeries{
+		{1000.0, 48.5},
+		{1400.0, 2025.0},
+		{1600.0, 99.0},
+		{1800.0, 200.0}}
+	assertValueDeepEqual(t, expected, aggregated)
+}
+
+func TestSumAverage(t *testing.T) {
+	aggregator := aggregators.New(
+		1000.0,
+		2000.0,
+		aggregators.Sum,
+		200.0,
+		aggregators.Avg,
+		aggregators.None)
+	aggregator.Add(tsdb.TimeSeries{
+		{1000.0, 42.0}, {1030.0, 54.0}, {1199.999, 49.5},
+		{1401.0, 20.0}, {1599.0, 30.0},
+		{1836.0, 98.0}})
+	aggregator.Add(tsdb.TimeSeries{
+		{1500.0, 1025.0},
+		{1600.0, 99.0},
+		{1800.0, 198.0}, {1801.0, 202.0}, {1999.1, 200.0}})
+	aggregator.Add(tsdb.TimeSeries{
+		{1400.0, 1975.0},
+		{1450.0, 2000.0},
+		{1599.0, 2025.0},
+		{1599.1, 2050.0},
+		{1599.2, 2075.0}})
+	aggregator.Add(nil)
+	aggregated := aggregator.Aggregate()
+	expected := tsdb.TimeSeries{
+		{1000.0, 48.5},
+		{1400.0, 3075.0},
+		{1600.0, 99.0},
+		{1800.0, 298.0}}
+	assertValueDeepEqual(t, expected, aggregated)
+}
+
+func TestAverageStrangeStartAndEnd(t *testing.T) {
+	aggregator := aggregators.New(
+		1057.0,
+		1938.0,
+		aggregators.Avg,
+		200.0,
+		aggregators.Avg,
+		aggregators.NaN)
+	aggregator.Add(tsdb.TimeSeries{
+		{1057.0, 30.0}, {1199.0, 40.0},
+		{1401.0, 20.0}, {1599.0, 30.0},
+		{1836.0, 98.0}})
+	aggregated := aggregator.Aggregate()
+	expected := tsdb.TimeSeries{
+		{1000.0, 35.0},
+		{1400.0, 25.0},
+		{1800.0, 98.0}}
+	assertValueDeepEqual(t, expected, aggregated)
+}
+
+func TestStartEqualsEnd(t *testing.T) {
+	aggregators.New(
+		1057.0,
+		1057.0,
+		aggregators.Avg,
+		200.0,
+		aggregators.Avg,
+		aggregators.NaN)
+	aggregators.New(
+		1000.0,
+		1000.0,
+		aggregators.Avg,
+		200.0,
+		aggregators.Avg,
+		aggregators.None)
+}
+
+func TestNegativeStart(t *testing.T) {
+	aggregator := aggregators.New(
+		-29028.0,
+		29028.0,
+		aggregators.Avg,
+		10000.0,
+		aggregators.Avg,
+		aggregators.NaN)
+	aggregator.Add(tsdb.TimeSeries{
+		{-29028.0, -60.0}, {-21000.0, -50.0},
+		{-3000.0, -5.0}, {3000.0, 5.0},
+		{29027.0, 43.0}})
+	aggregated := aggregator.Aggregate()
+	expected := tsdb.TimeSeries{
+		{-30000.0, -55.0},
+		{-10000.0, -5.0},
+		{0, 5.0}, {20000.0, 43.0}}
+	assertValueDeepEqual(t, expected, aggregated)
+}
+
+func TestAverageNone(t *testing.T) {
+	aggregator := aggregators.New(
+		1000.0,
+		2000.0,
+		aggregators.Avg,
+		200.0,
+		aggregators.Avg,
+		aggregators.None)
+	aggregated := aggregator.Aggregate()
+	if len(aggregated) != 0 {
+		t.Error("Expected no aggregation")
+	}
+}
+
+func assertValueDeepEqual(t *testing.T, expected, actual interface{}) {
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v, got %v", expected, actual)
+	}
+}

--- a/tsdb/aggregators/api.go
+++ b/tsdb/aggregators/api.go
@@ -7,19 +7,120 @@ import (
 	"github.com/Symantec/scotty/tsdb"
 )
 
-// NewAverage returns an aggregator that averages time series.
+// Aggregator instances correspond to OpenTSDB aggregators such as
+// sum, avg, count, max, etc.
+type Aggregator struct {
+	aggListCreater func(size int) aggregatorListType
+	updaterCreater updaterCreaterType
+}
+
+var (
+	Avg = &Aggregator{
+		aggListCreater: func(size int) aggregatorListType {
+			return make(averageListType, size)
+		},
+		updaterCreater: kNaN,
+	}
+	Count = &Aggregator{
+		aggListCreater: func(size int) aggregatorListType {
+			return make(countListType, size)
+		},
+		updaterCreater: kZero,
+	}
+	Max = &Aggregator{
+		aggListCreater: func(size int) aggregatorListType {
+			return make(maxListType, size)
+		},
+		updaterCreater: kNaN,
+	}
+	Sum = &Aggregator{
+		aggListCreater: func(size int) aggregatorListType {
+			return make(sumListType, size)
+		},
+		updaterCreater: kNaN,
+	}
+)
+
+var (
+	kAggregatorsByName = map[string]*Aggregator{
+		"avg":   Avg,
+		"count": Count,
+		"max":   Max,
+		"sum":   Sum,
+	}
+)
+
+// ByName returns the aggregator with given name or nil, false if no aggregator
+// matches given name
+func ByName(aggregatorName string) (*Aggregator, bool) {
+	result, ok := kAggregatorsByName[aggregatorName]
+	return result, ok
+}
+
+// Names returns all the aggregator names.
+func Names() (result []string) {
+	for key := range kAggregatorsByName {
+		result = append(result, key)
+	}
+	return
+}
+
+// FillPolicy describes how to handle missing values after downsampling
+type FillPolicy int
+
+const (
+	// None is the default. Do not emit missing values.
+	None FillPolicy = iota
+	// NaN behaves the same as None for now
+	NaN
+	// Null behaves the same as None for now
+	Null
+	// Zero means emit zero when no values are present in a downsample range
+	Zero
+)
+
+var (
+	kFillPoliciesByName = map[string]FillPolicy{
+		"none": None,
+		"nan":  NaN,
+		"null": Null,
+		"zero": Zero,
+	}
+)
+
+// ByFillPolicyName returns the fill policy with given name or None, false if
+// no fill policy matches given name
+func ByFillPolicyName(fillPolicyName string) (FillPolicy, bool) {
+	result, ok := kFillPoliciesByName[fillPolicyName]
+	return result, ok
+}
+
+// New returns an instance that aggregates time series.
 //
-// The returned aggregator is intended to work like the average aggregator in
-// tsdb with the following differences. First, down sampling is required
-// whereas it is optional in real tsdb. Second, this aggregator treats missing
-// values as NaN instead of using linear interpolation to guess missing
-// values.
+// The aggregator parameter specifies the type of aggrgation.
+//
+// The downsampleAggregator parameter specifies the type of aggregation to
+// use when downsampling.
 //
 // start and end are the start and end times in seconds since Jan 1, 1970 for
 // the aggregation. Time series passed to the Add() method of returned
-// aggregator must fall within start inclusive and end exclusive. downSample
-// is the down sample time in seconds. NewAverage treats downSample
-// values less than 1.0 as 1.0.
-func NewAverage(start, end, downSample float64) tsdb.Aggregator {
-	return newAverage(start, end, downSample)
+// aggregator must fall within start and end inclusive.
+
+// downSample is the down sample time in seconds. New treats downSample
+// values less than 1.0 as 1.0
+//
+// fillPolicy is the FillPolicy to use when downsampling.
+func New(
+	start, end float64,
+	aggregator *Aggregator,
+	downSample float64,
+	downSampleAggregator *Aggregator,
+	fillPolicy FillPolicy) tsdb.Aggregator {
+	return _new(
+		start,
+		end,
+		aggregator,
+		downSample,
+		downSampleAggregator,
+		fillPolicy)
 }

--- a/tsdb/aggregators/average.go
+++ b/tsdb/aggregators/average.go
@@ -1,72 +1,29 @@
 package aggregators
 
-import (
-	"github.com/Symantec/scotty/tsdb"
-)
-
-type averageValueType struct {
-	Count uint
-	Sum   float64
+type averageListType []struct {
+	count uint
+	sum   float64
 }
 
-func (a *averageValueType) Add(value float64) {
-	a.Count++
-	a.Sum += value
+func (a averageListType) Len() int {
+	return len(a)
 }
 
-func (a *averageValueType) Average() float64 {
-	if a.Count == 0 {
-		return 0.0
-	}
-	return a.Sum / float64(a.Count)
+func (a averageListType) Add(index int, value float64) {
+	a[index].count++
+	a[index].sum += value
 }
 
-type averageType struct {
-	averages         []averageValueType
-	downSamplePolicy downSamplePolicyType
+func (a averageListType) Get(index int) (float64, bool) {
+	if a[index].count == 0 {
+		return 0.0, false
+	}
+	return a[index].sum / float64(a[index].count), true
 }
 
-func newAverage(start, end, downSample float64) tsdb.Aggregator {
-	if end < start {
-		panic("end cannot be less than start")
+func (a averageListType) Clear() {
+	for i := range a {
+		a[i].count = 0
+		a[i].sum = 0
 	}
-	result := &averageType{
-		downSamplePolicy: newDownSamplePolicyType(start, downSample),
-	}
-	result.averages = make([]averageValueType, result.downSamplePolicy.IndexOf(end)+1)
-	return result
-}
-
-func (a *averageType) Add(values tsdb.TimeSeries) {
-	valueLen := len(values)
-	for startIdx, endIdx := 0, 0; startIdx < valueLen; startIdx = endIdx {
-		endIdx = a.downSamplePolicy.NextSample(values, startIdx)
-		downsampledValue := average(values[startIdx:endIdx])
-		downSampledIdx := a.downSamplePolicy.IndexOf(values[startIdx].Ts)
-		a.averages[downSampledIdx].Add(downsampledValue)
-	}
-}
-
-func (a *averageType) Aggregate() (result tsdb.TimeSeries) {
-	for i := range a.averages {
-		if a.averages[i].Count > 0 {
-			result = append(result, tsdb.TsValue{
-				Ts:    a.downSamplePolicy.TSOf(i),
-				Value: a.averages[i].Average(),
-			})
-		}
-	}
-	return
-}
-
-func average(values tsdb.TimeSeries) float64 {
-	count := len(values)
-	if count == 0 {
-		panic("Can't average empty set")
-	}
-	sum := 0.0
-	for i := range values {
-		sum += values[i].Value
-	}
-	return sum / float64(count)
 }

--- a/tsdb/aggregators/average_test.go
+++ b/tsdb/aggregators/average_test.go
@@ -1,81 +1,50 @@
 package aggregators_test
 
 import (
-	"github.com/Symantec/scotty/tsdb"
 	"github.com/Symantec/scotty/tsdb/aggregators"
-	"reflect"
 	"testing"
 )
 
-func TestAverage(t *testing.T) {
-	aggregator := aggregators.NewAverage(1000.0, 2000.0, 200.0)
-	aggregator.Add(tsdb.TimeSeries{
-		{1000.0, 42.0}, {1030.0, 54.0}, {1199.999, 49.5},
-		{1401.0, 20.0}, {1599.0, 30.0},
-		{1836.0, 98.0}})
-	aggregator.Add(tsdb.TimeSeries{
-		{1500.0, 1025.0},
-		{1600.0, 99.0},
-		{1800.0, 198.0}, {1801.0, 202.0}, {1999.1, 200.0}})
-	aggregator.Add(tsdb.TimeSeries{
-		{1400.0, 1975.0},
-		{1450.0, 2000.0},
-		{1599.0, 2025.0},
-		{1599.1, 2050.0},
-		{1599.2, 2075.0}})
-	aggregator.Add(nil)
-	aggregated := aggregator.Aggregate()
-	expected := tsdb.TimeSeries{
-		{1000.0, 48.5},
-		{1400.0, 1025.0},
-		{1600.0, 99.0},
-		{1800.0, 149.0}}
-	assertValueDeepEqual(t, expected, aggregated)
+func TestAvgNone(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Avg, aggregators.None)
+	tester.ExpectNoneForNoValues()
+	tester.Expect(5.0, 5.0)
+	tester.ExpectNoneForNoValues()
+	tester.ExpectNoneForNoValues()
+	tester.Expect(3.5, 1.0, 2.0, 3.0, 8.0)
+	tester.Expect(1.25, -1.25, 1.5, 3.5)
+	tester.Verify(t)
 }
 
-func TestAverageStrangeStartAndEnd(t *testing.T) {
-	aggregator := aggregators.NewAverage(1057.0, 1938.0, 200.0)
-	aggregator.Add(tsdb.TimeSeries{
-		{1057.0, 30.0}, {1199.0, 40.0},
-		{1401.0, 20.0}, {1599.0, 30.0},
-		{1836.0, 98.0}})
-	aggregated := aggregator.Aggregate()
-	expected := tsdb.TimeSeries{
-		{1000.0, 35.0},
-		{1400.0, 25.0},
-		{1800.0, 98.0}}
-	assertValueDeepEqual(t, expected, aggregated)
+func TestAvgNaN(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Avg, aggregators.NaN)
+	tester.ExpectNoneForNoValues()
+	tester.Expect(5.0, 5.0)
+	tester.ExpectNoneForNoValues()
+	tester.ExpectNoneForNoValues()
+	tester.Expect(2.5, 1.0, 2.0, 3.0, 4.0)
+	tester.Expect(1.25, -1.25, 1.5, 3.5)
+	tester.Verify(t)
 }
 
-func TestStartEqualsEnd(t *testing.T) {
-	aggregators.NewAverage(1057.0, 1057.0, 200.0)
-	aggregators.NewAverage(1000.0, 1000.0, 200.0)
+func TestAvgNull(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Avg, aggregators.Null)
+	tester.ExpectNoneForNoValues()
+	tester.Expect(5.0, 5.0)
+	tester.ExpectNoneForNoValues()
+	tester.ExpectNoneForNoValues()
+	tester.Expect(2.5, 1.0, 2.0, 3.0, 4.0)
+	tester.Expect(1.25, -1.25, 1.5, 3.5)
+	tester.Verify(t)
 }
 
-func TestNegativeStart(t *testing.T) {
-	aggregator := aggregators.NewAverage(-29028.0, 29028.0, 10000.0)
-	aggregator.Add(tsdb.TimeSeries{
-		{-29028.0, -60.0}, {-21000.0, -50.0},
-		{-3000.0, -5.0}, {3000.0, 5.0},
-		{29027.0, 43.0}})
-	aggregated := aggregator.Aggregate()
-	expected := tsdb.TimeSeries{
-		{-30000.0, -55.0},
-		{-10000.0, -5.0},
-		{0, 5.0}, {20000.0, 43.0}}
-	assertValueDeepEqual(t, expected, aggregated)
-}
-
-func TestAverageNone(t *testing.T) {
-	aggregator := aggregators.NewAverage(1000.0, 2000.0, 200.0)
-	aggregated := aggregator.Aggregate()
-	if len(aggregated) != 0 {
-		t.Error("Expected no aggregation")
-	}
-}
-
-func assertValueDeepEqual(t *testing.T, expected, actual interface{}) {
-	if !reflect.DeepEqual(expected, actual) {
-		t.Errorf("Expected %v, got %v", expected, actual)
-	}
+func TestAvgZero(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Avg, aggregators.Zero)
+	tester.Expect(0.0)
+	tester.Expect(5.0, 5.0)
+	tester.Expect(0.0)
+	tester.Expect(0.0)
+	tester.Expect(2.5, 1.0, 2.0, 3.0, 4.0)
+	tester.Expect(1.25, -1.25, 1.5, 3.5)
+	tester.Verify(t)
 }

--- a/tsdb/aggregators/count.go
+++ b/tsdb/aggregators/count.go
@@ -1,0 +1,21 @@
+package aggregators
+
+type countListType []uint64
+
+func (a countListType) Len() int {
+	return len(a)
+}
+
+func (a countListType) Add(index int, value float64) {
+	a[index]++
+}
+
+func (a countListType) Get(index int) (float64, bool) {
+	return float64(a[index]), true
+}
+
+func (a countListType) Clear() {
+	for i := range a {
+		a[i] = 0
+	}
+}

--- a/tsdb/aggregators/count_test.go
+++ b/tsdb/aggregators/count_test.go
@@ -1,0 +1,50 @@
+package aggregators_test
+
+import (
+	"github.com/Symantec/scotty/tsdb/aggregators"
+	"testing"
+)
+
+func TestCountNone(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Count, aggregators.None)
+	tester.Expect(0.0)
+	tester.Expect(1.0, 5.0)
+	tester.Expect(0.0)
+	tester.Expect(0.0)
+	tester.Expect(4.0, 1.0, 2.0, 3.0, 4.0)
+	tester.Expect(3.0, -1.25, 1.5, 3.5)
+	tester.Verify(t)
+}
+
+func TestCountNaN(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Count, aggregators.NaN)
+	tester.Expect(0.0)
+	tester.Expect(1.0, 5.0)
+	tester.Expect(0.0)
+	tester.Expect(0.0)
+	tester.Expect(4.0, 1.0, 2.0, 3.0, 4.0)
+	tester.Expect(3.0, -1.25, 1.5, 3.5)
+	tester.Verify(t)
+}
+
+func TestCountNull(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Count, aggregators.Null)
+	tester.Expect(0.0)
+	tester.Expect(1.0, 5.0)
+	tester.Expect(0.0)
+	tester.Expect(0.0)
+	tester.Expect(4.0, 1.0, 2.0, 3.0, 4.0)
+	tester.Expect(3.0, -1.25, 1.5, 3.5)
+	tester.Verify(t)
+}
+
+func TestCountZero(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Count, aggregators.Zero)
+	tester.Expect(0.0)
+	tester.Expect(1.0, 5.0)
+	tester.Expect(0.0)
+	tester.Expect(0.0)
+	tester.Expect(4.0, 1.0, 2.0, 3.0, 4.0)
+	tester.Expect(3.0, -1.25, 1.5, 3.5)
+	tester.Verify(t)
+}

--- a/tsdb/aggregators/downsample.go
+++ b/tsdb/aggregators/downsample.go
@@ -9,6 +9,10 @@ type downSamplePolicyType struct {
 	downSampleSize int64
 }
 
+// start is the starting time in seconds after Jan 1, 1970.
+// downSampleSize is the length of each time slice in seconds.
+// newDownSampleSize adjusts start to be a multiple of downSampleSize and makes
+// that adjusted start be index 0.
 func newDownSamplePolicyType(
 	start, downSampleSize float64) downSamplePolicyType {
 	if downSampleSize < 1.0 {
@@ -25,14 +29,20 @@ func newDownSamplePolicyType(
 		start: adjustedStartAsInt, downSampleSize: downSampleAsInt}
 }
 
+// IndexOf converts a timestamp to an index
 func (p *downSamplePolicyType) IndexOf(ts float64) int {
 	return int((int64(ts) - p.start) / p.downSampleSize)
 }
 
+// TSOf converts given index to a timestamp
 func (p *downSamplePolicyType) TSOf(index int) float64 {
 	return float64(p.start + int64(index)*p.downSampleSize)
 }
 
+// Given a starting index, NextSample returns the first index in given
+// time series that begins the next time slice. If start is in the last
+// time slice in given time series, NextSample returns the length of given
+// time series.
 func (p *downSamplePolicyType) NextSample(
 	values tsdb.TimeSeries, start int) int {
 	index := p.IndexOf(values[start].Ts)

--- a/tsdb/aggregators/max.go
+++ b/tsdb/aggregators/max.go
@@ -1,0 +1,27 @@
+package aggregators
+
+type maxListType []struct {
+	valid bool
+	max   float64
+}
+
+func (a maxListType) Len() int {
+	return len(a)
+}
+
+func (a maxListType) Add(index int, value float64) {
+	if !a[index].valid || value > a[index].max {
+		a[index].max = value
+		a[index].valid = true
+	}
+}
+
+func (a maxListType) Get(index int) (float64, bool) {
+	return a[index].max, a[index].valid
+}
+
+func (a maxListType) Clear() {
+	for i := range a {
+		a[i].valid = false
+	}
+}

--- a/tsdb/aggregators/max_test.go
+++ b/tsdb/aggregators/max_test.go
@@ -1,0 +1,54 @@
+package aggregators_test
+
+import (
+	"github.com/Symantec/scotty/tsdb/aggregators"
+	"testing"
+)
+
+func TestMaxNone(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Max, aggregators.None)
+	tester.ExpectNoneForNoValues()
+	tester.Expect(5.0, 5.0)
+	tester.ExpectNoneForNoValues()
+	tester.ExpectNoneForNoValues()
+	tester.ExpectNoneForNoValues()
+	tester.Expect(2.0, 1.0, 2.0, 1.75, -1.0)
+	tester.Expect(19.5, 19.5, 4.25, 3.5)
+	tester.Verify(t)
+}
+
+func TestMaxNaN(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Max, aggregators.NaN)
+	tester.ExpectNoneForNoValues()
+	tester.Expect(5.0, 5.0)
+	tester.ExpectNoneForNoValues()
+	tester.ExpectNoneForNoValues()
+	tester.ExpectNoneForNoValues()
+	tester.Expect(2.0, 1.0, 2.0, 1.75, -1.0)
+	tester.Expect(19.5, 19.5, 4.25, 3.5)
+	tester.Verify(t)
+}
+
+func TestMaxNull(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Max, aggregators.Null)
+	tester.ExpectNoneForNoValues()
+	tester.Expect(5.0, 5.0)
+	tester.ExpectNoneForNoValues()
+	tester.ExpectNoneForNoValues()
+	tester.ExpectNoneForNoValues()
+	tester.Expect(2.0, 1.0, 2.0, 1.75, -1.0)
+	tester.Expect(19.5, 19.5, 4.25, 3.5)
+	tester.Verify(t)
+}
+
+func TestMaxZero(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Max, aggregators.Zero)
+	tester.Expect(0.0)
+	tester.Expect(5.0, 5.0)
+	tester.Expect(0.0)
+	tester.Expect(0.0)
+	tester.Expect(0.0)
+	tester.Expect(2.0, 1.0, 2.0, 1.75, -1.0)
+	tester.Expect(19.5, 19.5, 4.25, 3.5)
+	tester.Verify(t)
+}

--- a/tsdb/aggregators/specific_aggregator_test.go
+++ b/tsdb/aggregators/specific_aggregator_test.go
@@ -1,0 +1,97 @@
+package aggregators_test
+
+import (
+	"github.com/Symantec/scotty/tsdb"
+	"github.com/Symantec/scotty/tsdb/aggregators"
+	"testing"
+)
+
+const (
+	kMaxSampleSize = 1000
+)
+
+type expectedResultsType struct {
+	Answer float64
+	Valid  bool
+	Values []float64
+}
+
+type aggregatorTesterType struct {
+	aggregator *aggregators.Aggregator
+	fillPolicy aggregators.FillPolicy
+	expected   []expectedResultsType
+}
+
+func newAggregatorTester(
+	aggregator *aggregators.Aggregator,
+	fp aggregators.FillPolicy) *aggregatorTesterType {
+	return &aggregatorTesterType{
+		aggregator: aggregator, fillPolicy: fp}
+}
+
+func (a *aggregatorTesterType) ExpectNoneForNoValues() {
+	a.expect(0.0, false, nil)
+}
+
+func (a *aggregatorTesterType) ExpectNone(values ...float64) {
+	a.expect(0.0, false, values)
+}
+
+func (a *aggregatorTesterType) Expect(answer float64, values ...float64) {
+	a.expect(answer, true, values)
+}
+
+func (a *aggregatorTesterType) expect(
+	answer float64, valid bool, values []float64) {
+	if len(values) > kMaxSampleSize {
+		panic("Too many values")
+	}
+	a.expected = append(
+		a.expected,
+		expectedResultsType{
+			Answer: answer,
+			Valid:  valid,
+			Values: values,
+		})
+}
+
+func (a *aggregatorTesterType) Verify(t *testing.T) {
+	length := len(a.expected)
+	agg := aggregators.New(
+		0, float64(length)*kMaxSampleSize,
+		aggregators.Sum,
+		kMaxSampleSize,
+		a.aggregator,
+		a.fillPolicy)
+	var timeSeries tsdb.TimeSeries
+	for i := range a.expected {
+		for j, val := range a.expected[i].Values {
+			timeSeries = append(
+				timeSeries,
+				tsdb.TsValue{
+					float64(i)*kMaxSampleSize + float64(j),
+					val})
+		}
+	}
+	agg.Add(timeSeries)
+	aggregatedTimeSeries := agg.Aggregate()
+	aggIdx := 0
+	for i := range a.expected {
+		if !a.expected[i].Valid {
+			continue
+		}
+		if aggIdx >= len(aggregatedTimeSeries) || aggregatedTimeSeries[aggIdx].Ts != float64(i)*kMaxSampleSize {
+			t.Error(
+				"Timestamps don't match. No value was emitted when one was expected or the other way around. Or maybe the Len() function is wrong.")
+			return
+		}
+		if a.expected[i].Answer != aggregatedTimeSeries[aggIdx].Value {
+			t.Errorf(
+				"Expected %g for %v, got %g",
+				a.expected[i].Answer,
+				a.expected[i].Values,
+				aggregatedTimeSeries[aggIdx].Value)
+		}
+		aggIdx++
+	}
+}

--- a/tsdb/aggregators/sum.go
+++ b/tsdb/aggregators/sum.go
@@ -1,0 +1,26 @@
+package aggregators
+
+type sumListType []struct {
+	sum   float64
+	valid bool
+}
+
+func (a sumListType) Len() int {
+	return len(a)
+}
+
+func (a sumListType) Add(index int, value float64) {
+	a[index].sum += value
+	a[index].valid = true
+}
+
+func (a sumListType) Get(index int) (float64, bool) {
+	return a[index].sum, a[index].valid
+}
+
+func (a sumListType) Clear() {
+	for i := range a {
+		a[i].sum = 0.0
+		a[i].valid = false
+	}
+}

--- a/tsdb/aggregators/sum_test.go
+++ b/tsdb/aggregators/sum_test.go
@@ -1,0 +1,46 @@
+package aggregators_test
+
+import (
+	"github.com/Symantec/scotty/tsdb/aggregators"
+	"testing"
+)
+
+func TestSumNone(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Sum, aggregators.None)
+	tester.ExpectNoneForNoValues()
+	tester.Expect(5.0, 5.0)
+	tester.ExpectNoneForNoValues()
+	tester.Expect(10.0, 1.0, 2.0, 3.0, 4.0)
+	tester.Expect(3.75, -1.25, 1.5, 3.5)
+	tester.Verify(t)
+}
+
+func TestSumNaN(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Sum, aggregators.NaN)
+	tester.ExpectNoneForNoValues()
+	tester.Expect(5.0, 5.0)
+	tester.ExpectNoneForNoValues()
+	tester.Expect(10.0, 1.0, 2.0, 3.0, 4.0)
+	tester.Expect(3.75, -1.25, 1.5, 3.5)
+	tester.Verify(t)
+}
+
+func TestSumNull(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Sum, aggregators.Null)
+	tester.ExpectNoneForNoValues()
+	tester.Expect(5.0, 5.0)
+	tester.ExpectNoneForNoValues()
+	tester.Expect(10.0, 1.0, 2.0, 3.0, 4.0)
+	tester.Expect(3.75, -1.25, 1.5, 3.5)
+	tester.Verify(t)
+}
+
+func TestSumZero(t *testing.T) {
+	tester := newAggregatorTester(aggregators.Sum, aggregators.Zero)
+	tester.Expect(0.0)
+	tester.Expect(5.0, 5.0)
+	tester.Expect(0.0)
+	tester.Expect(10.0, 1.0, 2.0, 3.0, 4.0)
+	tester.Expect(3.75, -1.25, 1.5, 3.5)
+	tester.Verify(t)
+}

--- a/tsdb/aggregators/updaters.go
+++ b/tsdb/aggregators/updaters.go
@@ -1,0 +1,154 @@
+package aggregators
+
+// updaterCreaterType instances are responsible for creating an updaterType
+// based on the the number of time slices and the fill policy
+// Unspecified fill policies are implicitly the same as None.
+type updaterCreaterType map[FillPolicy]func(
+	size int, fp FillPolicy) updaterType
+
+var (
+	// Use NaN for missing values when fill policy is None, not linear
+	// interpolation. NaN is treated as a missing value in aggregations
+	kNaN = updaterCreaterType{
+		None: newNaNUpdater,
+		Zero: newZeroUpdater,
+	}
+	// use zero for missing values when fill policy is None. Used by the
+	// count aggregator.
+	kZero = updaterCreaterType{
+		None: newZeroUpdater,
+		NaN:  newNaNUpdater,
+		Null: newNaNUpdater,
+	}
+	// Used exclusively by the pdiff aggregator.
+	kPdiff = updaterCreaterType{
+		None: newPdiffUpdater,
+	}
+)
+
+// Get returns a brand new updaterType based on number of time slices and
+// the fill policy.
+func (f updaterCreaterType) Get(
+	size int, fp FillPolicy) updaterType {
+	factory := f[fp]
+	if factory == nil {
+		factory = f[None]
+	}
+	return factory(size, fp)
+}
+
+// The nanUpdaterType ignores missing values.
+type nanUpdaterType struct {
+}
+
+func newNaNUpdater(unusedSize int, unusedFp FillPolicy) updaterType {
+	return nanUpdaterType{}
+}
+
+func (n nanUpdaterType) Update(
+	downAgg getByIndexType, aggregators adderType) {
+	length := downAgg.Len()
+	for i := 0; i < length; i++ {
+		downValue, ok := downAgg.Get(i)
+		if ok {
+			aggregators.Add(i, downValue)
+		}
+	}
+}
+
+// The zeroUpdaterType substitutes zero for missing values.
+type zeroUpdaterType struct {
+}
+
+func newZeroUpdater(unusedSize int, unusedFp FillPolicy) updaterType {
+	return zeroUpdaterType{}
+}
+
+func (z zeroUpdaterType) Update(
+	downAgg getByIndexType, aggregators adderType) {
+	length := downAgg.Len()
+	for i := 0; i < length; i++ {
+		downValue, ok := downAgg.Get(i)
+		if ok {
+			aggregators.Add(i, downValue)
+		} else {
+			aggregators.Add(i, 0.0)
+		}
+	}
+}
+
+// linearInterpolationType does linear interpolation
+type linearInterpolationType struct {
+	// Linear interpolated values stored here. The index represents the
+	// time slice
+	Values []float64
+	// Start index. Can't do linear interpolation before first known value
+	Start int
+	// end index. Can't do linear interpolation after last known value.
+	End int
+}
+
+// Init initializes this instance with g doing linear interpolation.
+func (l *linearInterpolationType) Init(g getByIndexType) {
+	length := g.Len()
+	if length != len(l.Values) {
+		panic("Lengths don't match")
+	}
+	l.Start = 0
+	l.End = 0
+	lastValidIndex := -1
+	for i := 0; i < length; i++ {
+		value, ok := g.Get(i)
+		if ok {
+			l.Values[i] = value
+			if lastValidIndex >= 0 {
+				diff := i - lastValidIndex
+				left := diff - 1
+				right := 1
+
+				for j := lastValidIndex + 1; j < i; j++ {
+					lpart := l.Values[lastValidIndex] * float64(left)
+					rpart := l.Values[i] * float64(right)
+					l.Values[j] = (lpart + rpart) / float64(diff)
+					left--
+					right++
+				}
+			} else {
+				l.Start = i
+			}
+			lastValidIndex = i
+			l.End = i + 1
+		}
+	}
+}
+
+// For pdiff.
+type pdiffUpdaterType struct {
+	interpolation linearInterpolationType
+	fillPolicy    FillPolicy
+}
+
+func newPdiffUpdater(size int, fp FillPolicy) updaterType {
+	return &pdiffUpdaterType{
+		interpolation: linearInterpolationType{
+			Values: make([]float64, size),
+		},
+		fillPolicy: fp,
+	}
+}
+
+func (p *pdiffUpdaterType) Update(
+	downAgg getByIndexType, aggregators adderType) {
+	// Use linear interpolation to approximate the deltas of counter metrics.
+	// If at 11:59 metric is 100 and at 12:02 metric is 190, we can still
+	// say that at 12:00 increase is 30 /min.
+	p.interpolation.Init(downAgg)
+	for i := p.interpolation.Start; i < p.interpolation.End-1; i++ {
+		diff := p.interpolation.Values[i+1] - p.interpolation.Values[i]
+		if diff >= 0 {
+			aggregators.Add(i, diff)
+		} else if p.fillPolicy == Zero {
+			aggregators.Add(i, 0)
+		}
+	}
+}

--- a/tsdbimpl/tsdbimpl_test.go
+++ b/tsdbimpl/tsdbimpl_test.go
@@ -86,7 +86,13 @@ func TestAPI(t *testing.T) {
 		appStatus,
 		"/foo",
 		func(start, end float64) (tsdb.Aggregator, error) {
-			return aggregators.NewAverage(start, end, 20.0), nil
+			return aggregators.New(
+				start,
+				end,
+				aggregators.Avg,
+				20.0,
+				aggregators.Avg,
+				aggregators.NaN), nil
 		},
 		500.0, 600.0,
 		nil); err != nil {
@@ -112,7 +118,13 @@ func TestAPI(t *testing.T) {
 		appStatus,
 		"/not there",
 		func(start, end float64) (tsdb.Aggregator, error) {
-			return aggregators.NewAverage(start, end, 20.0), nil
+			return aggregators.New(
+				start,
+				end,
+				aggregators.Avg,
+				20.0,
+				aggregators.Avg,
+				aggregators.NaN), nil
 		},
 		500.0, 600.0,
 		nil); err != tsdbimpl.ErrNoSuchMetric {
@@ -123,7 +135,13 @@ func TestAPI(t *testing.T) {
 		appStatus,
 		"/bar",
 		func(start, end float64) (tsdb.Aggregator, error) {
-			return aggregators.NewAverage(start, end, 20.0), nil
+			return aggregators.New(
+				start,
+				end,
+				aggregators.Avg,
+				20.0,
+				aggregators.Avg,
+				aggregators.NaN), nil
 		},
 		500.0, 1000.0,
 		nil); err != nil {
@@ -149,7 +167,13 @@ func TestAPI(t *testing.T) {
 		appStatus,
 		"/foo",
 		func(start, end float64) (tsdb.Aggregator, error) {
-			return aggregators.NewAverage(start, end, 20.0), nil
+			return aggregators.New(
+				start,
+				end,
+				aggregators.Avg,
+				20.0,
+				aggregators.Avg,
+				aggregators.NaN), nil
 		},
 		501.0, 539.0,
 		nil); err != nil {
@@ -178,7 +202,13 @@ func TestAPI(t *testing.T) {
 		appStatus,
 		"/foo",
 		func(start, end float64) (tsdb.Aggregator, error) {
-			return aggregators.NewAverage(start, end, 20.0), nil
+			return aggregators.New(
+				start,
+				end,
+				aggregators.Avg,
+				20.0,
+				aggregators.Avg,
+				aggregators.NaN), nil
 		},
 		400.0, 700.0,
 		options); err != nil {
@@ -227,7 +257,13 @@ func TestAPI(t *testing.T) {
 		appStatus,
 		"/foo",
 		func(start, end float64) (tsdb.Aggregator, error) {
-			return aggregators.NewAverage(start, end, 20.0), nil
+			return aggregators.New(
+				start,
+				end,
+				aggregators.Avg,
+				20.0,
+				aggregators.Avg,
+				aggregators.NaN), nil
 		},
 		700.0, 900.0,
 		options); err != nil {
@@ -250,7 +286,13 @@ func TestAPI(t *testing.T) {
 		appStatus,
 		"/foo",
 		func(start, end float64) (tsdb.Aggregator, error) {
-			return aggregators.NewAverage(start, end, 20.0), nil
+			return aggregators.New(
+				start,
+				end,
+				aggregators.Avg,
+				20.0,
+				aggregators.Avg,
+				aggregators.NaN), nil
 		},
 		400.0, 700.0,
 		options); err != nil {
@@ -292,7 +334,13 @@ func TestAPI(t *testing.T) {
 		appStatus,
 		"/foo",
 		func(start, end float64) (tsdb.Aggregator, error) {
-			return aggregators.NewAverage(start, end, 20.0), nil
+			return aggregators.New(
+				start,
+				end,
+				aggregators.Avg,
+				20.0,
+				aggregators.Avg,
+				aggregators.NaN), nil
 		},
 		400.0, 700.0,
 		options); err != nil {
@@ -373,7 +421,13 @@ func TestAPI(t *testing.T) {
 		appStatus,
 		"/foo",
 		func(start, end float64) (tsdb.Aggregator, error) {
-			return aggregators.NewAverage(start, end, 20.0), nil
+			return aggregators.New(
+				start,
+				end,
+				aggregators.Avg,
+				20.0,
+				aggregators.Avg,
+				aggregators.NaN), nil
 		},
 		700.0, 900.0,
 		options); err != nil {
@@ -404,7 +458,13 @@ func TestAPI(t *testing.T) {
 		appStatus,
 		"/foo",
 		func(start, end float64) (tsdb.Aggregator, error) {
-			return aggregators.NewAverage(start, end, 20.0), nil
+			return aggregators.New(
+				start,
+				end,
+				aggregators.Avg,
+				20.0,
+				aggregators.Avg,
+				aggregators.NaN), nil
 		},
 		400.0, 700.0,
 		options); err != nil {
@@ -453,7 +513,13 @@ func TestAPI(t *testing.T) {
 		appStatus,
 		"/foo",
 		func(start, end float64) (tsdb.Aggregator, error) {
-			return aggregators.NewAverage(start, end, 20.0), nil
+			return aggregators.New(
+				start,
+				end,
+				aggregators.Avg,
+				20.0,
+				aggregators.Avg,
+				aggregators.NaN), nil
 		},
 		400.0, 700.0,
 		options); err != nil {
@@ -487,7 +553,13 @@ func TestAPI(t *testing.T) {
 		appStatus,
 		"/foo",
 		func(start, end float64) (tsdb.Aggregator, error) {
-			return aggregators.NewAverage(start, end, 20.0), nil
+			return aggregators.New(
+				start,
+				end,
+				aggregators.Avg,
+				20.0,
+				aggregators.Avg,
+				aggregators.NaN), nil
 		},
 		400.0, 700.0,
 		options); err != tsdbimpl.ErrNoSuchMetric {


### PR DESCRIPTION
This change makes it easy to add new methods later on.

The code that contains the strategies for handling missing values can be found in tsdb/aggregators/updaters.go. I changed all aggregation methods except pdiff to report missing values as missing and not use linear interpolation. pdiff however still uses it. pdiff is used to downsample counter metrics. Since counter metrics always increase pdiff finds computes the change in the counter at each point. To do this effectively, it does use linear interpolation. To change the numerical method we use to estimate that change in a counter metric however is easy enough, we just change tsdb/aggregators/updaters.go and update the pdiff test.
