### PR TITLE
Introduce ResourceConnector, Resource and code Endpoint to them.

### DIFF
--- a/api.go
+++ b/api.go
@@ -123,7 +123,8 @@ type Logger interface {
 type Endpoint struct {
 	host           string
 	port           uint
-	connector      sources.Connector
+	connector      sources.ResourceConnector
+	resource       sources.Resource
 	onePollAtATime chan bool
 	state          *State
 	errored        bool
@@ -146,9 +147,9 @@ func (e *Endpoint) Port() uint {
 	return e.port
 }
 
-// Connector returns the connector of this endpoint.
-func (e *Endpoint) Connector() sources.Connector {
-	return e.connector
+// ConnectorName returns the name of the underlying connector in this endpoint.
+func (e *Endpoint) ConnectorName() string {
+	return e.connector.Name()
 }
 
 // Poll polls for metrics for this endpoint asynchronously.

--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -511,7 +511,7 @@ func (l *loggerType) LogStateChange(
 		timeTaken += newS.TimeSpentWaitingToConnect()
 		timeTaken += newS.TimeSpentWaitingToPoll()
 		l.CollectionTimesDist.Add(timeTaken)
-		dist := l.ByProtocolDist[e.Connector().Name()]
+		dist := l.ByProtocolDist[e.ConnectorName()]
 		if dist != nil {
 			dist.Add(timeTaken)
 		}

--- a/datastructs/datastructs_test.go
+++ b/datastructs/datastructs_test.go
@@ -247,49 +247,49 @@ func TestMarkHostsActiveExclusively(t *testing.T) {
 	assertValueEquals(t, 8, len(stats))
 	assertValueEquals(t, "host1", stats[0].EndpointId.HostName())
 	assertValueEquals(
-		t, "tricorder", stats[0].EndpointId.Connector().Name())
+		t, "tricorder", stats[0].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnApp", stats[0].Name)
 	assertValueEquals(t, false, stats[0].Active)
 
 	assertValueEquals(t, "host1", stats[1].EndpointId.HostName())
 	assertValueEquals(
-		t, "snmp", stats[1].EndpointId.Connector().Name())
+		t, "snmp", stats[1].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnotherApp", stats[1].Name)
 	assertValueEquals(t, false, stats[1].Active)
 
 	assertValueEquals(t, "host2", stats[2].EndpointId.HostName())
 	assertValueEquals(
-		t, "tricorder", stats[2].EndpointId.Connector().Name())
+		t, "tricorder", stats[2].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnApp", stats[2].Name)
 	assertValueEquals(t, true, stats[2].Active)
 
 	assertValueEquals(t, "host2", stats[3].EndpointId.HostName())
 	assertValueEquals(
-		t, "snmp", stats[3].EndpointId.Connector().Name())
+		t, "snmp", stats[3].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnotherApp", stats[3].Name)
 	assertValueEquals(t, true, stats[3].Active)
 
 	assertValueEquals(t, "host3", stats[4].EndpointId.HostName())
 	assertValueEquals(
-		t, "tricorder", stats[4].EndpointId.Connector().Name())
+		t, "tricorder", stats[4].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnApp", stats[4].Name)
 	assertValueEquals(t, false, stats[4].Active)
 
 	assertValueEquals(t, "host3", stats[5].EndpointId.HostName())
 	assertValueEquals(
-		t, "snmp", stats[5].EndpointId.Connector().Name())
+		t, "snmp", stats[5].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnotherApp", stats[5].Name)
 	assertValueEquals(t, false, stats[5].Active)
 
 	assertValueEquals(t, "host4", stats[6].EndpointId.HostName())
 	assertValueEquals(
-		t, "tricorder", stats[6].EndpointId.Connector().Name())
+		t, "tricorder", stats[6].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnApp", stats[6].Name)
 	assertValueEquals(t, true, stats[6].Active)
 
 	assertValueEquals(t, "host4", stats[7].EndpointId.HostName())
 	assertValueEquals(
-		t, "snmp", stats[7].EndpointId.Connector().Name())
+		t, "snmp", stats[7].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnotherApp", stats[7].Name)
 	assertValueEquals(t, true, stats[7].Active)
 
@@ -310,49 +310,49 @@ func TestMarkHostsActiveExclusively(t *testing.T) {
 	assertValueEquals(t, 8, len(stats))
 	assertValueEquals(t, "host1", stats[0].EndpointId.HostName())
 	assertValueEquals(
-		t, "tricorder", stats[0].EndpointId.Connector().Name())
+		t, "tricorder", stats[0].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnApp", stats[0].Name)
 	assertValueEquals(t, false, stats[0].Active)
 
 	assertValueEquals(t, "host1", stats[1].EndpointId.HostName())
 	assertValueEquals(
-		t, "snmp", stats[1].EndpointId.Connector().Name())
+		t, "snmp", stats[1].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnotherApp", stats[1].Name)
 	assertValueEquals(t, false, stats[1].Active)
 
 	assertValueEquals(t, "host2", stats[2].EndpointId.HostName())
 	assertValueEquals(
-		t, "tricorder", stats[2].EndpointId.Connector().Name())
+		t, "tricorder", stats[2].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnApp", stats[2].Name)
 	assertValueEquals(t, true, stats[2].Active)
 
 	assertValueEquals(t, "host2", stats[3].EndpointId.HostName())
 	assertValueEquals(
-		t, "snmp", stats[3].EndpointId.Connector().Name())
+		t, "snmp", stats[3].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnotherApp", stats[3].Name)
 	assertValueEquals(t, true, stats[3].Active)
 
 	assertValueEquals(t, "host3", stats[4].EndpointId.HostName())
 	assertValueEquals(
-		t, "tricorder", stats[4].EndpointId.Connector().Name())
+		t, "tricorder", stats[4].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnApp", stats[4].Name)
 	assertValueEquals(t, true, stats[4].Active)
 
 	assertValueEquals(t, "host3", stats[5].EndpointId.HostName())
 	assertValueEquals(
-		t, "snmp", stats[5].EndpointId.Connector().Name())
+		t, "snmp", stats[5].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnotherApp", stats[5].Name)
 	assertValueEquals(t, true, stats[5].Active)
 
 	assertValueEquals(t, "host4", stats[6].EndpointId.HostName())
 	assertValueEquals(
-		t, "tricorder", stats[6].EndpointId.Connector().Name())
+		t, "tricorder", stats[6].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnApp", stats[6].Name)
 	assertValueEquals(t, true, stats[6].Active)
 
 	assertValueEquals(t, "host4", stats[7].EndpointId.HostName())
 	assertValueEquals(
-		t, "snmp", stats[7].EndpointId.Connector().Name())
+		t, "snmp", stats[7].EndpointId.ConnectorName())
 	assertValueEquals(t, "AnotherApp", stats[7].Name)
 	assertValueEquals(t, true, stats[7].Active)
 

--- a/sources/api.go
+++ b/sources/api.go
@@ -6,13 +6,34 @@ import (
 )
 
 // Connector connects to a particular type of source.
-// Connector implementations must be safe to use with multiple goroutines.
+// Connector instances must be safe to use with multiple goroutines.
 type Connector interface {
 	Connect(host string, port uint) (Poller, error)
 	Name() string
 }
 
-// Poller polls metrics from a particular source
+// Resource represents a resource to connect to.
+//
+// Resource instances are long lived and therefore can amortize the cost of
+// opening up a connection again and again from scratch using a host and port.
+// A particular Resource instance is valid only for the ResourceConnector
+// that created it.
+type Resource interface{}
+
+// ResourceConnector is implemented by Connector instances that support
+// amortizing the cost of connecting. Clients should check at runtime if a
+// Connector instance implements this interface. If it does they should use
+// use the instance with this interface instead of the Connector interface.
+// Like Connector, ResourceConnector instances must be safe to use with
+// multiple goroutines.
+type ResourceConnector interface {
+	NewResource(host string, port uint) Resource
+	ResourceConnect(resource Resource) (Poller, error)
+	Name() string
+}
+
+// Poller polls metrics from a particular source. Generally, a Poller
+// instance may be polled once and then must be closed.
 type Poller interface {
 	Poll() (metrics.List, error)
 	Close() error


### PR DESCRIPTION
This makes it possible to amortize the cost of connecting to an
endpoint.

This PR lays the needed groundwork for effectively integrating with rpcclientpool. The existing sources.Connector interface is inadequate as its Connect method take a physical host and port. We introduce sources.Resource, long lived instances which represent a resource with which to connect. We add the sources.ResourceConnector interface which is an optional interface that connects to a resource instead of a physical host and port. The tricorder rpc implements ResourceConnector; the tricorder json does not.

If the sources.Connector interface does not implement ResourceConnector, scotty wraps it in a default ResourceConnector implementation that simply stores the physical host and port in the resource instance so that as far as scotty is concerned, all sources work the same way. Scotty creates each Resource instance once and connects using resources instead of with physical host and port.  Its these resource instances that will eventually hold the *rpcclientpool.ClientResource instances.
