### PR TITLE
Endpoint to try with different connectors.

### DIFF
--- a/datastructs/api.go
+++ b/datastructs/api.go
@@ -175,9 +175,9 @@ func (a *ApplicationStatuses) ActiveEndpointIds() (
 // Application represents a particular application in the fleet.
 // Application instances are immutable.
 type Application struct {
-	name      string
-	connector sources.Connector
-	port      uint
+	name       string
+	connectors sources.ConnectorList
+	port       uint
 }
 
 // Name returns the name of application
@@ -186,8 +186,8 @@ func (a *Application) Name() string {
 }
 
 // Connector returns the connector for the application
-func (a *Application) Connector() sources.Connector {
-	return a.connector
+func (a *Application) Connectors() sources.ConnectorList {
+	return a.connectors
 }
 
 // Port returns the port number of the application
@@ -231,8 +231,8 @@ func NewApplicationListBuilder() *ApplicationListBuilder {
 
 // Add adds an application.
 func (a *ApplicationListBuilder) Add(
-	port uint, applicationName string, connector sources.Connector) {
-	a.add(port, applicationName, connector)
+	port uint, applicationName string, connectors sources.ConnectorList) {
+	a.add(port, applicationName, connectors)
 }
 
 // Read application names and ports from a config file into this builder.

--- a/datastructs/datastructs_test.go
+++ b/datastructs/datastructs_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/Symantec/scotty"
 	"github.com/Symantec/scotty/metrics"
+	"github.com/Symantec/scotty/sources"
 	"github.com/Symantec/scotty/sources/snmpsource"
 	"github.com/Symantec/scotty/sources/trisource"
 	"github.com/Symantec/scotty/store"
@@ -179,8 +180,12 @@ func newStore(
 
 func TestMarkHostsActiveExclusively(t *testing.T) {
 	alBuilder := NewApplicationListBuilder()
-	alBuilder.Add(35, "AnApp", trisource.GetConnector())
-	alBuilder.Add(92, "AnotherApp", snmpsource.NewConnector("community"))
+	alBuilder.Add(
+		35, "AnApp", sources.ConnectorList{trisource.GetConnector()})
+	alBuilder.Add(
+		92,
+		"AnotherApp",
+		sources.ConnectorList{snmpsource.NewConnector("community")})
 	appList := alBuilder.Build()
 	appStatus := NewApplicationStatuses(
 		appList,
@@ -360,7 +365,7 @@ func TestMarkHostsActiveExclusively(t *testing.T) {
 
 func TestHighPriorityEviction(t *testing.T) {
 	alBuilder := NewApplicationListBuilder()
-	alBuilder.Add(37, "AnApp", trisource.GetConnector())
+	alBuilder.Add(37, "AnApp", sources.ConnectorList{trisource.GetConnector()})
 	appList := alBuilder.Build()
 	// 9 values
 	appStatus := NewApplicationStatuses(
@@ -515,11 +520,11 @@ func assertApplication(
 	if port != app.Port() {
 		t.Errorf("Expected '%d', got '%d'", port, app.Port())
 	}
-	if protocol != app.Connector().Name() {
+	if protocol != app.Connectors()[0].Name() {
 		t.Errorf(
 			"Expected '%s', got '%s'",
 			protocol,
-			app.Connector().Name())
+			app.Connectors()[0].Name())
 	}
 }
 

--- a/lib/preference/api.go
+++ b/lib/preference/api.go
@@ -1,0 +1,76 @@
+// Package preference contains routines for maintaining order of preference
+// for expensive processes such as RPC methods.
+package preference
+
+// Preference instances maintain the order of preference for RPC methods to
+// complete an API call. Although this documentation assumes the client
+// is managing RPC methods, a Preference instance may be used to maintain
+// order of preference for completing any expensive process.
+//
+// Clients store RPC methods in a slice by order of preference. The best
+// method is stored in [0]; the next best in [1] etc. A preference instance
+// tells the client what order to try RPC methods according to their index in
+// that slice. If there are 4 RPC methods, the Indexes() method will return
+// {0, 1, 2, 3} which means try the most preferred method first; the next
+// preferred second and so forth. Generally, the client will have success
+// with the most preferred method, but when that method fails, the client can
+// tell the instance what method was successful.
+//
+// When the client finds a successful method, the client calls SetFirstIndex
+// to tell the instance what method was successful. If client calls
+// SetFirstIndex(2), Index() will return {2, 0, 1, 3} which means try the
+// method at index 2 first since that one brought success, then try the most
+// preferred method then the next preferred method and finally the least
+// preferred method. Sometimes it may be desirable to try the most preferred
+// method first eventually.
+//
+// For that reason, a Preference instance may be set up so that after
+// SetFirstIndex() is called n consecutive times with the same index, the
+// first index to try is reset to 0 to ensure that eventually the most
+// preferred RPC method is tried first once again.
+type Preference struct {
+	// These 2 fields stay the same
+	count                    int
+	consecutiveCallsForReset int
+	// These fields change
+	_firstIndex      int
+	consecutiveCalls int
+}
+
+// New creates a brand new Preference instance.
+// count is the number of RPC methods to try.
+// consecutiveCallsForReset is how many consecutive times SetFirstIndex()
+// must be called with the same index to reset the first index
+// to 0. consecutiveCallsForReset <= 0 means never reset.
+//
+// New panics if count <= 0.
+func New(count int, consecutiveCallsForReset int) *Preference {
+	if count <= 0 {
+		panic("count must be at least 1")
+	}
+	return &Preference{
+		count: count,
+		consecutiveCallsForReset: consecutiveCallsForReset,
+	}
+}
+
+// Indexes returns the order to try RPC methods by index
+func (p *Preference) Indexes() []int {
+	return p.indexes()
+}
+
+// FirstIndex returns the index of the first RPC method to try
+func (p *Preference) FirstIndex() int {
+	return p.firstIndex()
+}
+
+// SetFirstIndex tells this instance the index of the RPC method that
+// succeeded.
+//
+// SetFirstIndex panics if index < 0 or index >= count.
+func (p *Preference) SetFirstIndex(index int) {
+	if index < 0 || index >= p.count {
+		panic("required: 0 <= index < p.count")
+	}
+	p.setFirstIndex(index)
+}

--- a/lib/preference/preference.go
+++ b/lib/preference/preference.go
@@ -1,0 +1,36 @@
+package preference
+
+func (p *Preference) indexes() []int {
+	result := make([]int, p.count)
+	result[0] = p._firstIndex
+	index := 1
+	for i := 0; i < p.count; i++ {
+		if i != p._firstIndex {
+			result[index] = i
+			index++
+		}
+	}
+	return result
+}
+
+func (p *Preference) firstIndex() int {
+	return p._firstIndex
+}
+
+func (p *Preference) setFirstIndex(index int) {
+	if index != p._firstIndex {
+		p.consecutiveCalls = 0
+	}
+	p.consecutiveCalls++
+	if p.consecutiveCalls == p.consecutiveCallsForReset {
+		p._firstIndex = 0
+		p.consecutiveCalls = 0
+	} else {
+		p._firstIndex = index
+	}
+	// Don't bother tracking consecutive calls user didn't specify
+	// consecutive calls needed for reset
+	if p.consecutiveCallsForReset == 0 {
+		p.consecutiveCalls = 0
+	}
+}

--- a/lib/preference/preference_test.go
+++ b/lib/preference/preference_test.go
@@ -1,0 +1,113 @@
+package preference_test
+
+import (
+	"github.com/Symantec/scotty/lib/preference"
+	"reflect"
+	"testing"
+)
+
+func TestNoReset(t *testing.T) {
+	p := preference.New(6, 0)
+	p.SetFirstIndex(4)
+	assertValueEquals(t, 4, p.FirstIndex())
+	p.SetFirstIndex(4)
+	assertValueEquals(t, 4, p.FirstIndex())
+	p.SetFirstIndex(4)
+	assertValueEquals(t, 4, p.FirstIndex())
+	p.SetFirstIndex(4)
+	assertValueEquals(t, 4, p.FirstIndex())
+	p.SetFirstIndex(1)
+	assertValueEquals(t, 1, p.FirstIndex())
+	p.SetFirstIndex(0)
+	assertValueEquals(t, 0, p.FirstIndex())
+
+	p = preference.New(3, -1)
+	p.SetFirstIndex(2)
+	assertValueEquals(t, 2, p.FirstIndex())
+	p.SetFirstIndex(2)
+	assertValueEquals(t, 2, p.FirstIndex())
+	p.SetFirstIndex(2)
+	assertValueEquals(t, 2, p.FirstIndex())
+}
+
+func TestAPI(t *testing.T) {
+	p := preference.New(5, 3)
+	assertValueEquals(t, 0, p.FirstIndex())
+	assertValueDeepEquals(
+		t, []int{0, 1, 2, 3, 4}, p.Indexes())
+	// 1st consecutive call for 4
+	p.SetFirstIndex(4)
+	// 2nd consecutive call for 4
+	p.SetFirstIndex(4)
+	assertValueEquals(t, 4, p.FirstIndex())
+	assertValueEquals(t, 4, p.FirstIndex())
+	assertValueEquals(t, 4, p.FirstIndex())
+	assertValueEquals(t, 4, p.FirstIndex())
+	assertValueDeepEquals(
+		t, []int{4, 0, 1, 2, 3}, p.Indexes())
+	assertValueDeepEquals(
+		t, []int{4, 0, 1, 2, 3}, p.Indexes())
+	assertValueDeepEquals(
+		t, []int{4, 0, 1, 2, 3}, p.Indexes())
+	assertValueDeepEquals(
+		t, []int{4, 0, 1, 2, 3}, p.Indexes())
+	assertValueEquals(t, 4, p.FirstIndex())
+	// 1st consecutive call for 1
+	p.SetFirstIndex(1)
+	assertValueEquals(t, 1, p.FirstIndex())
+	assertValueDeepEquals(
+		t, []int{1, 0, 2, 3, 4}, p.Indexes())
+	// 2st consecutive call for 1
+	p.SetFirstIndex(1)
+	// 3rd consecutive call for 1 resets FirstIndex to 0
+	p.SetFirstIndex(1)
+	assertValueEquals(t, 0, p.FirstIndex())
+	assertValueDeepEquals(
+		t, []int{0, 1, 2, 3, 4}, p.Indexes())
+	// 4th consecutive call for 1 becomes like the 1st consecutive call
+	p.SetFirstIndex(1)
+	assertValueEquals(t, 1, p.FirstIndex())
+	assertValueDeepEquals(
+		t, []int{1, 0, 2, 3, 4}, p.Indexes())
+	// 2 consecutive calls for 3
+	p.SetFirstIndex(3)
+	p.SetFirstIndex(3)
+	assertValueEquals(t, 3, p.FirstIndex())
+	assertValueDeepEquals(
+		t, []int{3, 0, 1, 2, 4}, p.Indexes())
+	// 2 consecutive calls for 2
+	p.SetFirstIndex(2)
+	p.SetFirstIndex(2)
+	assertValueEquals(t, 2, p.FirstIndex())
+	assertValueDeepEquals(
+		t, []int{2, 0, 1, 3, 4}, p.Indexes())
+	// 3 consecutive call for 2
+	p.SetFirstIndex(2)
+	assertValueEquals(t, 0, p.FirstIndex())
+	assertValueDeepEquals(
+		t, []int{0, 1, 2, 3, 4}, p.Indexes())
+	// 3 consecutive call for 0 still 0
+	p.SetFirstIndex(0)
+	p.SetFirstIndex(0)
+	p.SetFirstIndex(0)
+	assertValueEquals(t, 0, p.FirstIndex())
+	assertValueDeepEquals(
+		t, []int{0, 1, 2, 3, 4}, p.Indexes())
+}
+
+func assertValueEquals(t *testing.T, expected, actual interface{}) bool {
+	if expected != actual {
+		t.Errorf("Expected %v, got %v", expected, actual)
+		return false
+	}
+	return true
+}
+
+func assertValueDeepEquals(
+	t *testing.T, expected, actual interface{}) bool {
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v, got %v", expected, actual)
+		return false
+	}
+	return true
+}

--- a/sources/api.go
+++ b/sources/api.go
@@ -12,6 +12,11 @@ type Connector interface {
 	Name() string
 }
 
+// ConnectorList is a list of connectors.
+// First element of list is most prefered; last element is least preferred.
+// Instances of this type must be treated as immutable.
+type ConnectorList []Connector
+
 // Resource represents a resource to connect to.
 //
 // Resource instances are long lived and therefore can amortize the cost of

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/Symantec/scotty"
 	"github.com/Symantec/scotty/metrics"
+	"github.com/Symantec/scotty/sources"
 	"github.com/Symantec/scotty/sources/trisource"
 	"github.com/Symantec/scotty/store"
 	"github.com/Symantec/scotty/tsdb"
@@ -20,13 +21,13 @@ import (
 
 var (
 	kEndpoint0 = scotty.NewEndpointWithConnector(
-		"host1", 1001, trisource.GetConnector())
+		"host1", 1001, sources.ConnectorList{trisource.GetConnector()})
 	kEndpoint1 = scotty.NewEndpointWithConnector(
-		"host2", 1002, trisource.GetConnector())
+		"host2", 1002, sources.ConnectorList{trisource.GetConnector()})
 	kEndpoint2 = scotty.NewEndpointWithConnector(
-		"host3", 1001, trisource.GetConnector())
+		"host3", 1001, sources.ConnectorList{trisource.GetConnector()})
 	kEndpoint3 = scotty.NewEndpointWithConnector(
-		"host4", 1002, trisource.GetConnector())
+		"host4", 1002, sources.ConnectorList{trisource.GetConnector()})
 	kError          = errors.New("An error")
 	kUsualTimeStamp = time.Date(2016, 7, 8, 14, 11, 0, 0, time.Local)
 	kNoMetaData     = newExpectedMetaData()

--- a/tsdbimpl/tsdbimpl_test.go
+++ b/tsdbimpl/tsdbimpl_test.go
@@ -3,6 +3,7 @@ package tsdbimpl_test
 import (
 	"github.com/Symantec/scotty/datastructs"
 	"github.com/Symantec/scotty/metrics"
+	"github.com/Symantec/scotty/sources"
 	"github.com/Symantec/scotty/sources/trisource"
 	"github.com/Symantec/scotty/store"
 	"github.com/Symantec/scotty/tsdb"
@@ -42,8 +43,10 @@ func addValues(
 
 func TestAPI(t *testing.T) {
 	alBuilder := datastructs.NewApplicationListBuilder()
-	alBuilder.Add(37, "AnApp", trisource.GetConnector())
-	alBuilder.Add(97, "AnotherApp", trisource.GetConnector())
+	alBuilder.Add(
+		37, "AnApp", sources.ConnectorList{trisource.GetConnector()})
+	alBuilder.Add(
+		97, "AnotherApp", sources.ConnectorList{trisource.GetConnector()})
 	appList := alBuilder.Build()
 	appStatus := datastructs.NewApplicationStatuses(
 		appList,


### PR DESCRIPTION
This CL adds the the ability to try multiple methods of gathering metrics from an endpoint and remembering which one succeeded. In this PR, each endpoint takes a slice of connector ordered by preference instead of just a single connector. For now, each endpoint gets a slice with just one connector. After this PR is in, I will stage another PR that introduces gathering metrics from tricorder JSON, then tricorder endpoints will get 2 connectors. The original go rpc one first and then the json one.
