### PR TITLE
Make history=0 in links from showAllApps page.

### DIFF
--- a/apps/scotty/showallapps/showallapps.go
+++ b/apps/scotty/showallapps/showallapps.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -168,9 +167,8 @@ func (h *Handler) ServeHTTP(
 func (h *Handler) newView(
 	apps []*datastructs.ApplicationStatus) *view {
 	result := &view{
-		Apps: apps,
-		History: strconv.Itoa(
-			int((h.CollectionFreq + time.Minute - 1) / time.Minute)),
+		Apps:    apps,
+		History: "0",
 	}
 	result.Summary.Init(apps)
 	return result


### PR DESCRIPTION
With 30s poll intervals, history=1 would crash firefox with the amount of json. history=0 ensures that we get only the latest value for each metric. Longer histories for a subtree of metrics is fine but firefox can't handle rendering the json for all metrics when the history is long.
