### PR TITLE
Don't average timestamps when rolling up for LMM.

### DIFF
--- a/store/api.go
+++ b/store/api.go
@@ -611,6 +611,9 @@ func (s *Store) TsdbTimeSeries(
 
 // NamedIteratorForEndpoint returns an iterator for the given name that
 // iterates over metric values for all known timestamps for the given endpoint.
+// Since the name is used to track progress of iterating over the given
+// endpoint, caller should avoid creating two iterators with the same name
+// iterating over the same endpoint at the same time.
 // Although returned iterator iterates over values and timestamps in no
 // particular order, it will iterate over values of the same metric by
 // increasing timestamp. For now, this method uses the
@@ -643,11 +646,12 @@ func (s *Store) NamedIteratorForEndpoint(
 // reports summarised values by averaging / rolling up values for each time
 // period.
 //
-// NamedIteratorForEndpointRollUp summarises values by averaging both the
-// values and the timestamps of values for each time period.
+// NamedIteratorForEndpointRollUp summarises values by averaging the
+// values for each time period and emits each average with the start time
+// of the corresponding time period.
 // When averaging integer values, it rounds the average to the nearest integer.
 // For non-numeric values such as strings, it summarises by reporting the
-// first encountered value and timestamp in each time period.
+// first encountered value with the start timestamp of each time period.
 // It ignores any inactive flags encountered when summarising values.
 //
 // For each metric, NamedIteratorForEndpointRollUp reports at most one

--- a/store/iterators.go
+++ b/store/iterators.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"math"
 	"sort"
 )
 
@@ -239,6 +240,7 @@ func (n *rollUpNamedIteratorType) Next(result *Record) bool {
 			}
 		}
 		n.namedIteratorType.Next(&record)
+		record.TimeStamp = math.Floor(record.TimeStamp/n.interval) * n.interval
 		n.aggregator.Add(&record)
 	}
 	if n.aggregator.IsEmpty() {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -792,22 +792,22 @@ func TestRollUpIterator(t *testing.T) {
 	assertValueEquals(t, 610.0, aStore.TimeLeft("anIterator"))
 
 	expected := newExpectedTsValues()
-	expected.Add("Int", 120059.5, int64(26667))
-	expected.Add("Float", 96048.0, 5.75)
+	expected.Add("Int", 120000.0, int64(26667))
+	expected.Add("Float", 96000.0, 5.75)
 	expected.Add("String", 96000.0, "hello")
-	expected.Add("Inactive", 120089.25, 24.0)
+	expected.Add("Inactive", 120000.0, 24.0)
 
-	expected.Add("Int", 120275.0, int64(31500))
+	expected.Add("Int", 120240.0, int64(31500))
 	expected.Add("Float", 96240.0, 9.125)
 	expected.Add("String", 96240.0, "bee")
 
-	expected.Add("Int", 120415.0, int64(23250))
-	expected.Add("Float", 96410.0, 1.875)
-	expected.Add("String", 96400.0, "long")
-	expected.Add("Inactive", 120410.0, 11.0)
+	expected.Add("Int", 120360.0, int64(23250))
+	expected.Add("Float", 96360.0, 1.875)
+	expected.Add("String", 96360.0, "long")
+	expected.Add("Inactive", 120360.0, 11.0)
 
-	expected.Add("Float", 96500.0, 3.1875)
-	expected.Add("String", 96500.0, "near")
+	expected.Add("Float", 96480.0, 3.1875)
+	expected.Add("String", 96480.0, "near")
 
 	beginning := expected.Checkpoint()
 
@@ -946,10 +946,10 @@ func TestRollUpIterator(t *testing.T) {
 	playback.Play(aStore, kEndpoint0)
 
 	expected = newExpectedTsValues()
-	expected.Add("Int", 120510.0, int64(28000))
-	expected.Add("Float", 96611.0, 12.0)
+	expected.Add("Int", 120480.0, int64(28000))
+	expected.Add("Float", 96600.0, 12.0)
 	expected.Add("String", 96600.0, "far")
-	expected.Add("Inactive", 120500.0, 8.3)
+	expected.Add("Inactive", 120480.0, 8.3)
 
 	iterator, _ = aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
@@ -1030,8 +1030,8 @@ func TestRollUpIteratorInt8(t *testing.T) {
 	playback.Play(aStore, kEndpoint0)
 
 	expected := newExpectedTsValues()
-	expected.Add("path", 30100.0, int8(1))
-	expected.Add("path", 30400.0, int8(-128))
+	expected.Add("path", 30000.0, int8(1))
+	expected.Add("path", 30300.0, int8(-128))
 	expected.Add("path", 30900.0, int8(127))
 
 	iterator, _ := aStore.NamedIteratorForEndpointRollUp(
@@ -1058,25 +1058,26 @@ func TestIteratorSamePathDifferentTypeRollUp(t *testing.T) {
 	playback.AddTimes(
 		0,
 		1200.0, 1210.0, 1220.0, 1230.0, 1240.0, 1250.0,
-		1260.0, 1270.0, 1280.0, 1290.0, 1300.0, 1310.0,
+		1260.0, 1270.0, 1280.0, 1290.0,
+		1330.0, 1340.0,
 		// Here to force first two periods to get written out
-		1320.0,
+		1380.0,
 	)
 	playback.Add(
 		"foo",
 		int64(1000), int64(1010), int64(1020),
 		float64(2030.0), float64(2040.0), float64(2050.0),
-		float64(2060.0), float64(2070.0), float64(2080.0),
-		"hello", "how", int64(1110),
+		float64(2060.0), float64(2070.0), float64(2080.0), int64(1110),
+		"hello", "how",
 		"yo",
 	)
 	playback.Play(aStore, kEndpoint0)
 
 	expected := newExpectedTsValues()
 
-	expected.Add("foo", 1225.0, int64(1525))
-	expected.Add("foo", 1280.0, float64(1830.0))
-	expected.Add("foo", 1290.0, "hello")
+	expected.Add("foo", 1200.0, int64(1525))
+	expected.Add("foo", 1260.0, float64(1830.0))
+	expected.Add("foo", 1320.0, "hello")
 
 	iterator, _ := aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
@@ -2554,7 +2555,7 @@ func TestWithDistributions(t *testing.T) {
 		})
 	expectedTsValues.Add(
 		"mint",
-		3200.0,
+		3000.0,
 		int64(74))
 
 	iterator, _ = aStore.NamedIteratorForEndpointRollUp(


### PR DESCRIPTION
This makes scotty not average timestamps. With this code, the grafana graphs from scotty match the grafana graphs from our backend.
