### PR TITLE
Introduce datastructs.ByHostAndName().

### DIFF
--- a/apps/scotty/showallapps/showallapps.go
+++ b/apps/scotty/showallapps/showallapps.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 )
@@ -127,37 +126,12 @@ type Handler struct {
 	CollectionFreq time.Duration
 }
 
-type byNameAndPort []*datastructs.ApplicationStatus
-
-func (b byNameAndPort) Len() int { return len(b) }
-
-func (b byNameAndPort) Less(i, j int) bool {
-	ihostname := b[i].EndpointId.HostName()
-	jhostname := b[j].EndpointId.HostName()
-	if ihostname < jhostname {
-		return true
-	} else if jhostname < ihostname {
-		return false
-	} else if b[i].EndpointId.Port() < b[j].EndpointId.Port() {
-		return true
-	}
-	return false
-}
-
-func (b byNameAndPort) Swap(i, j int) {
-	b[j], b[i] = b[i], b[j]
-}
-
-func sortByNameAndPort(rows []*datastructs.ApplicationStatus) {
-	sort.Sort(byNameAndPort(rows))
-}
-
 func (h *Handler) ServeHTTP(
 	w http.ResponseWriter, r *http.Request) {
 	r.ParseForm()
 	w.Header().Set("Content-Type", "text/html")
 	result := h.AS.All()
-	sortByNameAndPort(result)
+	datastructs.ByHostAndName(result)
 	v := h.newView(result)
 	if err := htmlTemplate.Execute(w, v); err != nil {
 		fmt.Fprintln(w, "Error in template: %v\n", err)

--- a/datastructs/api.go
+++ b/datastructs/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Symantec/scotty/sources"
 	"github.com/Symantec/scotty/store"
 	"io"
+	"sort"
 	"sync"
 	"time"
 )
@@ -61,6 +62,12 @@ func (a *ApplicationStatus) Staleness() time.Duration {
 		return 0
 	}
 	return time.Now().Sub(a.LastReadTime)
+}
+
+// ByHostAndName sorts list by the hostname and then by application name
+// in ascending order.
+func ByHostAndName(list []*ApplicationStatus) {
+	sort.Sort(byHostAndName(list))
 }
 
 // ApplicationStatuses is thread safe representation of application statuses

--- a/datastructs/datastructs.go
+++ b/datastructs/datastructs.go
@@ -16,6 +16,27 @@ import (
 	"time"
 )
 
+type byHostAndName []*ApplicationStatus
+
+func (b byHostAndName) Len() int { return len(b) }
+
+func (b byHostAndName) Less(i, j int) bool {
+	ihostname := b[i].EndpointId.HostName()
+	jhostname := b[j].EndpointId.HostName()
+	if ihostname < jhostname {
+		return true
+	} else if jhostname < ihostname {
+		return false
+	} else if b[i].Name < b[j].Name {
+		return true
+	}
+	return false
+}
+
+func (b byHostAndName) Swap(i, j int) {
+	b[j], b[i] = b[i], b[j]
+}
+
 type protocolType func(map[string]string) (sources.ConnectorList, error)
 
 func newTricorder(unused map[string]string) (sources.ConnectorList, error) {

--- a/datastructs/datastructs_test.go
+++ b/datastructs/datastructs_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Symantec/tricorder/go/tricorder"
 	"math"
 	"reflect"
-	"sort"
 	"testing"
 )
 
@@ -248,7 +247,7 @@ func TestMarkHostsActiveExclusively(t *testing.T) {
 	}
 
 	stats := appStatus.All()
-	sort.Sort(sortByHostPort(stats))
+	ByHostAndName(stats)
 	assertValueEquals(t, 8, len(stats))
 	assertValueEquals(t, "host1", stats[0].EndpointId.HostName())
 	assertValueEquals(
@@ -311,7 +310,7 @@ func TestMarkHostsActiveExclusively(t *testing.T) {
 	}
 
 	stats = appStatus.All()
-	sort.Sort(sortByHostPort(stats))
+	ByHostAndName(stats)
 	assertValueEquals(t, 8, len(stats))
 	assertValueEquals(t, "host1", stats[0].EndpointId.HostName())
 	assertValueEquals(
@@ -526,25 +525,4 @@ func assertApplication(
 			protocol,
 			app.Connectors()[0].Name())
 	}
-}
-
-type sortByHostPort []*ApplicationStatus
-
-func (s sortByHostPort) Len() int { return len(s) }
-
-func (s sortByHostPort) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s sortByHostPort) Less(i, j int) bool {
-	if s[i].EndpointId.HostName() < s[j].EndpointId.HostName() {
-		return true
-	}
-	if s[i].EndpointId.HostName() > s[j].EndpointId.HostName() {
-		return false
-	}
-	if s[i].EndpointId.Port() < s[j].EndpointId.Port() {
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
We move sorting endpoints by hostname and application name into its own
function because it is becoming a common use case for the various API
scotty will be supporting.
