### PR TITLE
Ha

### DIFF
--- a/consul/api.go
+++ b/consul/api.go
@@ -6,10 +6,40 @@ import (
 	"log"
 )
 
-// NewCoordinator returns a new coordinator for consul. The returned
-// coordinator writes any errors encountered to logger as the Lease method
-// on returned instance must block until success. The Consul agent runs
-// on the local machine at port 8500 so no other configuration is needed.
-func NewCoordinator(logger *log.Logger) (store.Coordinator, error) {
-	return newCoordinator(logger)
+type Coordinator struct {
+	coord    *coordinator
+	listener func(blocked bool)
+}
+
+// NewCoordinator returns a new coordinator for consul that implements
+// store.Coordinator.
+// The returned coordinator writes any errors encountered to logger as the
+// Lease method on returned instance must block until success.
+// The Consul agent runs on the local machine at port 8500 so no other
+// configuration is needed.
+func NewCoordinator(logger *log.Logger) (*Coordinator, error) {
+	result, err := newCoordinator(logger)
+	if err != nil {
+		return nil, err
+	}
+	return &Coordinator{coord: result}, nil
+}
+
+// Lease implements Lease from store.Coordinator
+func (c *Coordinator) Lease(leaseSpanInSeconds, timeToInclude float64) (
+	startTimeInclusive, endTimeExclusive float64) {
+	return c.coord.Lease(leaseSpanInSeconds, timeToInclude, c.listener)
+}
+
+// WithStateListener returns a new view to this same Coordinator that
+// monitors state. The Lease method on the returned view calls listener(true)
+// if it must block to acquire or extend the lease. Once it has the lease,
+// it calls listener(false) before returning. The Lease method on the
+// returned view makes no calls to listener if it determines that the
+// current lease is viable and can be returned as is.
+func (c *Coordinator) WithStateListener(
+	listener func(blocked bool)) store.Coordinator {
+	result := *c
+	result.listener = listener
+	return &result
 }

--- a/consul/api.go
+++ b/consul/api.go
@@ -1,0 +1,10 @@
+package consul
+
+import (
+	"github.com/Symantec/scotty/store"
+	"log"
+)
+
+func NewCoordinator(logger *log.Logger) (store.Coordinator, error) {
+	return newCoordinator(logger)
+}

--- a/consul/api.go
+++ b/consul/api.go
@@ -1,3 +1,4 @@
+// Package consul integrates scotty with Consul.
 package consul
 
 import (
@@ -5,6 +6,10 @@ import (
 	"log"
 )
 
+// NewCoordinator returns a new coordinator for consul. The returned
+// coordinator writes any errors encountered to logger as the Lease method
+// on returned instance must block until success. The Consul agent runs
+// on the local machine at port 8500 so no other configuration is needed.
 func NewCoordinator(logger *log.Logger) (store.Coordinator, error) {
 	return newCoordinator(logger)
 }

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -1,0 +1,222 @@
+package consul
+
+import (
+	"github.com/Symantec/scotty/store"
+	"github.com/hashicorp/consul/api"
+	"log"
+	"math"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	kNextStartKey = "service/scotty/nextStart"
+	kLockKey      = "service/scotty/leader"
+)
+
+type kernelType struct {
+	lock   *api.Lock
+	kv     *api.KV
+	logger *log.Logger
+}
+
+func (k *kernelType) mustSucceed(f func() error) {
+	sleepDur := 10 * time.Second
+	for err := f(); err != nil; err = f() {
+		k.logger.Printf("Consul Error: %v; retry in: %v", err, sleepDur)
+		time.Sleep(sleepDur)
+		sleepDur *= 2
+	}
+}
+
+func (k *kernelType) decode(raw []byte) (int64, error) {
+	if raw == nil {
+		return 0, nil
+	}
+	return strconv.ParseInt(string(raw), 10, 64)
+}
+
+func (k *kernelType) encode(value int64) []byte {
+	return ([]byte)(strconv.FormatInt(value, 10))
+}
+
+func (k *kernelType) EnsureLeadership() {
+	k.mustSucceed(func() error {
+		_, err := k.lock.Lock(nil)
+		if err == api.ErrLockHeld {
+			// We have the lock already so we are good
+			return nil
+		}
+		return err
+	})
+	return
+}
+
+func (k *kernelType) getNextStart() (nextStart int64, modifyIndex uint64) {
+	k.mustSucceed(func() error {
+		kvPair, _, err := k.kv.Get(kNextStartKey, nil)
+		if err != nil {
+			return err
+		}
+		if kvPair == nil {
+			return nil
+		}
+		ns, _ := k.decode(kvPair.Value)
+		nextStart = ns
+		modifyIndex = kvPair.ModifyIndex
+		return nil
+	})
+	return
+}
+
+func (k *kernelType) GetNextStart() int64 {
+	result, _ := k.getNextStart()
+	return result
+}
+
+func (k *kernelType) cas(nextStart int64, modifyIndex uint64) (
+	success bool) {
+	k.mustSucceed(func() error {
+		kvPair := &api.KVPair{
+			Key:         kNextStartKey,
+			ModifyIndex: modifyIndex,
+			Value:       k.encode(nextStart),
+		}
+		outcome, _, err := k.kv.CAS(kvPair, nil)
+		if err != nil {
+			return err
+		}
+		success = outcome
+		return nil
+	})
+	return
+}
+
+func (k *kernelType) CAS(lastStart, nextStart int64) bool {
+	start, modifyIndex := k.getNextStart()
+	// actual start had better match what we expect
+	if start != lastStart {
+		return false
+	}
+	return k.cas(nextStart, modifyIndex)
+}
+
+type coordinator struct {
+	kernel   kernelType
+	lock     sync.Mutex
+	start    int64
+	end      int64
+	updateCh chan struct{}
+}
+
+// ExtendLease is always run by a single goroutine on behalf of any
+// goroutines waiting on a new lease.
+func (c *coordinator) ExtendLease(
+	lastEndTime, minLeaseSpan, timeToInclude int64) {
+	nextStart := c.kernel.GetNextStart()
+
+	if nextStart != lastEndTime {
+		// If we get here, someone else leased time since we leased so we
+		// need to ensure we have leadership. Moreover, we must set the
+		// start of our lease to nextStart.
+		c.kernel.EnsureLeadership()
+		// Compute the new end time of our lease.
+		newEnd := timeToInclude + minLeaseSpan
+		if newEnd < nextStart+minLeaseSpan {
+			newEnd = nextStart + minLeaseSpan
+		}
+		if !c.kernel.CAS(nextStart, newEnd) {
+			// Oops, either the previous leader did more writing while we
+			// were waiting to become leader or we lost our leadership.
+			// Just start over by calling ourselves again
+			c.ExtendLease(lastEndTime, minLeaseSpan, timeToInclude)
+			return
+		}
+		c.lock.Lock()
+		defer c.lock.Unlock()
+		// Update our lease
+		c.start = nextStart
+		c.end = newEnd
+		// Signal that we are done extending and wake up anyone waiting on us.
+		close(c.updateCh)
+		c.updateCh = nil
+		return
+	}
+	// If we get here, no one else has leased since we leased. We can just
+	// extend our continguous block
+	newEnd := timeToInclude + minLeaseSpan
+	if !c.kernel.CAS(nextStart, newEnd) {
+		// Oops, someone else assumed leadership role. Just start over by
+		// calling ourselves again and returning immediately.
+		c.ExtendLease(lastEndTime, minLeaseSpan, timeToInclude)
+		return
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	// Update our lease
+	c.end = newEnd
+	// Signal that we are done extending and wake up anyone waiting on us.
+	close(c.updateCh)
+	c.updateCh = nil
+}
+
+func (c *coordinator) CheckExistingLease(minLeaseSpan, timeToInclude int64) (
+	start, end int64, updateCh <-chan struct{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if timeToInclude < c.end {
+		return c.start, c.end, nil
+	}
+	if c.updateCh == nil {
+		c.updateCh = make(chan struct{})
+		go c.ExtendLease(c.end, minLeaseSpan, timeToInclude)
+	}
+	updateCh = c.updateCh
+	return
+}
+
+func (c *coordinator) Lease(minLeaseSpan, timeToInclude float64) (
+	start, end float64) {
+	iMinLeaseSpan := roundUp(minLeaseSpan)
+	iTimeToInclude := roundUp(timeToInclude)
+	var updateCh <-chan struct{}
+	istart, iend, updateCh := c.CheckExistingLease(
+		iMinLeaseSpan, iTimeToInclude)
+	// Keep trying until we have an acceptable lease
+	for updateCh != nil {
+		<-updateCh
+		istart, iend, updateCh = c.CheckExistingLease(
+			iMinLeaseSpan, iTimeToInclude)
+	}
+	start = float64(istart)
+	end = float64(iend)
+	return
+}
+
+func newCoordinator(logger *log.Logger) (result store.Coordinator, err error) {
+	coord := &coordinator{}
+
+	// Best I can tell, these calls don't do any network RPC's. They seem to
+	// report errors only if programmer misuses.
+	client, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		return
+	}
+	coord.kernel.lock, err = client.LockKey(kLockKey)
+	if err != nil {
+		return
+	}
+	coord.kernel.kv = client.KV()
+	coord.kernel.logger = logger
+	result = coord
+	return
+}
+
+func roundUp(x float64) int64 {
+	fl := math.Floor(x)
+	if x == fl {
+		return int64(x)
+	}
+	return int64(fl + 1.0)
+}

--- a/store/coordinator_test.go
+++ b/store/coordinator_test.go
@@ -1,0 +1,107 @@
+package store_test
+
+import (
+	"github.com/Symantec/scotty/store"
+	"testing"
+)
+
+type fakeTsIterator struct {
+	Current float64
+	End     float64
+	Incr    float64
+}
+
+func (f *fakeTsIterator) Next(rec *store.Record) bool {
+	if f.Current >= f.End {
+		return false
+	}
+	rec.TimeStamp = f.Current
+	f.Current += f.Incr
+	return true
+}
+
+type fakeCoordinator struct {
+	start     float64
+	end       float64
+	nextStart float64
+	count     int
+}
+
+func (f *fakeCoordinator) Lease(
+	leaseSpanInSeconds float64, timeToInclude float64) (float64, float64) {
+	f.count++
+	if timeToInclude >= f.start && timeToInclude < f.end {
+		return f.start, f.end
+	}
+	f.start = f.nextStart
+	f.end = timeToInclude + leaseSpanInSeconds
+	if f.end < f.start+leaseSpanInSeconds {
+		f.end = f.start + leaseSpanInSeconds
+	}
+	return f.start, f.end
+}
+
+func (f *fakeCoordinator) SetNextStart(start float64) {
+	f.nextStart = start
+}
+
+func (f *fakeCoordinator) Verify(
+	t *testing.T, count int, start, end float64) {
+	if count != f.count {
+		t.Errorf("Expected %d leases, got %d", count, f.count)
+	}
+	if f.start != start || f.end != end {
+		t.Errorf("Expected lease (%v, %v), got (%v, %v)", start, end, f.start, f.end)
+	}
+}
+
+func runIteration(
+	t *testing.T,
+	iter store.Iterator,
+	expectedValues ...float64) {
+	for _, want := range expectedValues {
+		var rec store.Record
+		if !iter.Next(&rec) {
+			t.Fatal("Unexpected end of iterator")
+		}
+		got := rec.TimeStamp
+		if want != got {
+			t.Errorf("Want %v, got %v", want, got)
+		}
+	}
+}
+
+func TestCoordinate(t *testing.T) {
+	var iter store.Iterator = &fakeTsIterator{
+		Current: 200.0,
+		End:     400.0,
+		Incr:    10.0,
+	}
+	coord := &fakeCoordinator{}
+	// Leases go up in 30 second increments
+	iter = store.IteratorCoordinate(iter, coord, 30.0)
+	runIteration(t, iter, 200.0, 210.0, 220.0)
+	// Verify we are on 1st lease and it goes from 0 to 230
+	coord.Verify(t, 1, 0.0, 230.0)
+	runIteration(t, iter, 230.0, 240.0, 250.0, 260.0)
+	// Verify we are on 3rd lease and it goes from 0 to 290
+	coord.Verify(t, 3, 0.0, 290.0)
+	coord.SetNextStart(340.0)
+	// Even though we are on new start, current lease is still valid.
+	runIteration(t, iter, 270.0, 280.0)
+	coord.Verify(t, 3, 0.0, 290.0)
+	// Now we jump to 340
+	runIteration(t, iter, 340.0)
+	// 4th lease goes from 340 to 370
+	coord.Verify(t, 4, 340.0, 370.0)
+	runIteration(t, iter, 350.0, 360.0, 370.0)
+	// 5th lease runs to 400
+	coord.Verify(t, 5, 340.0, 400.0)
+	runIteration(t, iter, 380.0, 390)
+	coord.Verify(t, 5, 340.0, 400.0)
+	var rec store.Record
+	if iter.Next(&rec) {
+		t.Error("Exected no more, but got some")
+	}
+	coord.Verify(t, 5, 340.0, 400.0)
+}


### PR DESCRIPTION
High availability changes for scotty.

These changes allow scotty instances to talk to consul to work out leadership election for writing to kafka (or other persistent store). The guarantee made is that no two scotty processes will ever write metrics for the same time range.

We can later integrate with zookeeper if we choose by writing another implementation of store.Coordinator for zookeeper. I did consul as it is already written in go and has a nice go API.
