### PR TITLE
If scotty looses lease skips values decrement left to write.

### DIFF
--- a/pstore/api.go
+++ b/pstore/api.go
@@ -236,15 +236,21 @@ type ConsumerMetrics struct {
 // ConsumerMetricsStore stores metrics for a consumer.
 // ConsumerMetricStore instances are safe to use with multiple goroutines.
 type ConsumerMetricsStore struct {
-	w           *RecordWriterWithMetrics
-	filterer    store.Filterer
-	lock        sync.Mutex
-	recordCount uint64
+	w                  *RecordWriterWithMetrics
+	filterer           store.Filterer
+	lock               sync.Mutex
+	recordCount        uint64
+	removedRecordCount uint64
 }
 
 // Adds count to the total number of records consumer must write out.
 func (s *ConsumerMetricsStore) AddToRecordCount(count uint64) {
 	s.addToRecordCount(count)
+}
+
+// Removed count from the total number of records consumer must write out.
+func (s *ConsumerMetricsStore) RemoveFromRecordCount(count uint64) {
+	s.removeFromRecordCount(count)
 }
 
 // Returns true if consumer is to write out this record or false otherwise.

--- a/pstore/pstore.go
+++ b/pstore/pstore.go
@@ -309,13 +309,22 @@ func (s *ConsumerMetricsStore) metrics(m *ConsumerMetrics) {
 func (s *ConsumerMetricsStore) getRecordCount() uint64 {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	return s.recordCount
+	if s.recordCount > s.removedRecordCount {
+		return s.recordCount - s.removedRecordCount
+	}
+	return 0
 }
 
 func (s *ConsumerMetricsStore) addToRecordCount(count uint64) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.recordCount += count
+}
+
+func (s *ConsumerMetricsStore) removeFromRecordCount(count uint64) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.removedRecordCount += count
 }
 
 func toFilterer(w LimitedRecordWriter) store.Filterer {

--- a/store/coordinator_test.go
+++ b/store/coordinator_test.go
@@ -20,6 +20,14 @@ func (f *fakeTsIterator) Next(rec *store.Record) bool {
 	return true
 }
 
+func (f *fakeTsIterator) Name() string {
+	return "foo"
+}
+
+func (f *fakeTsIterator) Commit() {
+	// do nothing
+}
+
 type fakeCoordinator struct {
 	start     float64
 	end       float64
@@ -72,36 +80,63 @@ func runIteration(
 }
 
 func TestCoordinate(t *testing.T) {
-	var iter store.Iterator = &fakeTsIterator{
+	var iter store.NamedIterator = &fakeTsIterator{
 		Current: 200.0,
-		End:     400.0,
+		End:     500.0,
 		Incr:    10.0,
 	}
 	coord := &fakeCoordinator{}
+	var skipped uint64
+	updateSkipped := func(x uint64) {
+		skipped += x
+	}
 	// Leases go up in 30 second increments
-	iter = store.IteratorCoordinate(iter, coord, 30.0)
+	iter = store.NamedIteratorCoordinate(iter, coord, 30.0, updateSkipped)
 	runIteration(t, iter, 200.0, 210.0, 220.0)
 	// Verify we are on 1st lease and it goes from 0 to 230
 	coord.Verify(t, 1, 0.0, 230.0)
 	runIteration(t, iter, 230.0, 240.0, 250.0, 260.0)
 	// Verify we are on 3rd lease and it goes from 0 to 290
 	coord.Verify(t, 3, 0.0, 290.0)
+	iter.Commit()
+	if skipped != 0 {
+		t.Errorf("Expected 0 skipped, got %d", skipped)
+	}
 	coord.SetNextStart(340.0)
 	// Even though we are on new start, current lease is still valid.
 	runIteration(t, iter, 270.0, 280.0)
 	coord.Verify(t, 3, 0.0, 290.0)
 	// Now we jump to 340
 	runIteration(t, iter, 340.0)
+	// skip isn't updated until after we commit
+	if skipped != 0 {
+		t.Errorf("Expected 0 skipped, got %d", skipped)
+	}
+	iter.Commit()
+	if skipped != 5 {
+		t.Errorf("Expected 5 skipped, got %d", skipped)
+	}
 	// 4th lease goes from 340 to 370
 	coord.Verify(t, 4, 340.0, 370.0)
 	runIteration(t, iter, 350.0, 360.0, 370.0)
 	// 5th lease runs to 400
 	coord.Verify(t, 5, 340.0, 400.0)
+	coord.SetNextStart(600.0)
 	runIteration(t, iter, 380.0, 390)
 	coord.Verify(t, 5, 340.0, 400.0)
 	var rec store.Record
 	if iter.Next(&rec) {
 		t.Error("Exected no more, but got some")
 	}
-	coord.Verify(t, 5, 340.0, 400.0)
+	coord.Verify(t, 6, 600.0, 630.0)
+	// Skip not updated until after we commit
+	if skipped != 5 {
+		t.Errorf("Expected 5 skipped, got %d", skipped)
+	}
+	iter.Commit()
+	// Our iterator goes to 500 so we skipped last 10 making total skipped
+	// be 15.
+	if skipped != 15 {
+		t.Errorf("Expected 15 skipped, got %d", skipped)
+	}
 }


### PR DESCRIPTION
I discovered that if a running scotty is awaiting leadership to write to persistent store, that the number of records left for it to write keeps increasing. When that scotty finally acquires leadership, it skips over all the records that the old leader had written without also decrementing the number of records left to write. The result was that the scotty process that acquired leadership late would show that it had some fixed number of records left to write even though it simply skipped over those records because they were written by the old leader.

This PR fixes that bug. This PR does the following:
1. Apply the same filtering to the iterator of records to be written that the underlying writer does already to ensure we get an accurate count of skipped records.
2. When decorating the iterator to check the lease, keep track of how many records had to be skipped because they fall before the start of the lease
3. Don't record the number of records skipped until the iterator's progress is committed. This detail is very important to ensure that each skipped record is counted exactly once. 
