### PR TITLE
Track the approximate span of time the data store covers.

### DIFF
--- a/store/pages.go
+++ b/store/pages.go
@@ -47,6 +47,16 @@ func (p *tsPageType) Clear() {
 	*p = (*p)[:0]
 }
 
+func (p tsPageType) Latest() (latest float64, ok bool) {
+	length := len(p)
+	if length == 0 {
+		return
+	}
+	latest = p[length-1].TimeStamp
+	ok = true
+	return
+}
+
 func (p tsPageType) Len() int {
 	return len(p)
 }
@@ -88,6 +98,16 @@ func (p *pageType) Add(val tsValueType) {
 
 func (p *pageType) Clear() {
 	*p = (*p)[:0]
+}
+
+func (p pageType) Latest() (latest float64, ok bool) {
+	length := len(p)
+	if length == 0 {
+		return
+	}
+	latest = p[length-1].TimeStamp
+	ok = true
+	return
 }
 
 func (p pageType) IsFull() bool {

--- a/store/pageseries.go
+++ b/store/pageseries.go
@@ -358,6 +358,10 @@ func (t *timestampSeriesType) GiveUpPage(page *pageWithMetaDataType) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	if t.pages.GiveUpPage(page, nil) {
+		latest, ok := page.Times().Latest()
+		if ok {
+			t.metrics.UpdateLatestEvictedTimeStamp(latest)
+		}
 		t.metrics.RemoveTimeStampPage()
 	}
 }
@@ -461,6 +465,10 @@ func (t *timeSeriesType) GiveUpPage(page *pageWithMetaDataType) {
 	defer t.lock.Unlock()
 	oldLen := t.pages.Len()
 	if t.pages.GiveUpPage(page, nil) {
+		latest, ok := page.Values().Latest()
+		if ok {
+			t.metrics.UpdateLatestEvictedTimeStamp(latest)
+		}
 		t.metrics.RemoveValuePage(oldLen, page.Values().Len())
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -203,6 +203,14 @@ func (s *Store) registerMetrics(d *tricorder.DirectorySpec) (err error) {
 		return
 	}
 	if err = d.RegisterMetricInGroup(
+		"/timeSpan",
+		primitiveMetrics.TimeSpan,
+		storeGroup,
+		units.Second,
+		"Span of time in store"); err != nil {
+		return
+	}
+	if err = d.RegisterMetricInGroup(
 		"/valuePageCount",
 		metrics.PagesPerMetricDist.Sum,
 		storeGroup,


### PR DESCRIPTION
This PR adds a metric to track the approximate span of time that the scotty store covers.