### PR TITLE
Add retry primitive to scotty.

### DIFF
--- a/lib/retry/api.go
+++ b/lib/retry/api.go
@@ -1,0 +1,34 @@
+package retry
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Retry is an object that will perform an action until it succeeds.
+type Retry struct {
+	m    sync.Mutex
+	done uint32
+}
+
+// Do calls f once and returns the result of f until f returns nil. Once f
+// return nil, calling Do on this instance no longer calls f even if f changes
+// but simply returns nil. Calling Do on this instance with multiple
+// goroutines gates calls to f so that only only one goroutine at a time
+// calls f while the others block.
+func (r *Retry) Do(f func() error) error {
+	if atomic.LoadUint32(&r.done) == 1 {
+		return nil
+	}
+	// slow-path
+	r.m.Lock()
+	defer r.m.Unlock()
+	if r.done == 0 {
+		err := f()
+		if err != nil {
+			return err
+		}
+		atomic.StoreUint32(&r.done, 1)
+	}
+	return nil
+}


### PR DESCRIPTION
This works like sync.Once except that it allows us to rerun a function
until it succeeds. influx and opentsdb libraries succeed on creation, but
fail on write when actual pstore is down. If kafka is down, the kafka
library fails early on creation instead of on write.

We want the kafka library to fail on write instead of on creation when
the kafka backend is down. kafka can always come back online.
Therefore, we introduce this synchronisation primitive so that we keep
trying to set up the kafka connection when we write until we finally
succeed.