### PR TITLE
Add seqNo for saving progress on iterators.

### DIFF
--- a/store/api.go
+++ b/store/api.go
@@ -374,8 +374,9 @@ func NamedIteratorCoordinate(
 // NamedIterator with a particular name at a time to iterate over the same
 // group of items. If the caller creates multiple NamedIterator instances with
 // the same name to iterate over the same group of items and calls Commit on
-// all of them, the last iterator to save its progress wins overwriting the
-// progress of the others with its own.
+// all of them, the first iterator to save its progress wins. When the
+// the other iterators try to save their progress, they see the progress
+// already updated since they were created, so they don't save.
 type NamedIterator interface {
 	// Name returns the name of the iterator.
 	Name() string

--- a/store/iterators.go
+++ b/store/iterators.go
@@ -83,6 +83,7 @@ func (c *changedNamedIteratorType) Next(r *Record) bool {
 type namedIteratorDataType struct {
 	startTimeStamps map[int]float64
 	completed       map[*MetricInfo]float64
+	seqNo           uint64
 }
 
 type namedIteratorType struct {
@@ -90,6 +91,7 @@ type namedIteratorType struct {
 	timeSeriesCollection *timeSeriesCollectionType
 	// startTimeStamps does not change during this instance's lifetime
 	startTimeStamps map[int]float64
+	seqNo           uint64
 	timestamps      map[int][]float64
 	completed       map[*MetricInfo]float64
 	timeSeries      []*timeSeriesType
@@ -161,11 +163,13 @@ func (n *namedIteratorType) snapshot() *namedIteratorDataType {
 	if !n.hasNext() {
 		return &namedIteratorDataType{
 			startTimeStamps: n.nextStartTimeStamps(),
+			seqNo:           n.seqNo + 1,
 		}
 	}
 	return &namedIteratorDataType{
 		startTimeStamps: n.startTimeStamps,
 		completed:       copyCompleted(n.completed),
+		seqNo:           n.seqNo + 1,
 	}
 }
 
@@ -175,6 +179,7 @@ func (n *namedIteratorType) Name() string {
 
 func (n *namedIteratorType) Commit() {
 	n.timeSeriesCollection.saveProgress(n.name, n.snapshot())
+	n.seqNo++
 }
 
 func (n *namedIteratorType) hasNext() bool {


### PR DESCRIPTION
When a new persistent store is added to the config file, scotty must start writing data to it from that point in time rather than from the earliest data scotty has stored. We do this by fast forwarding the iterators for the added persistent store to the end of scotty. When we fast forward iterators, we must guarantee that they stay pointing to the end of scotty. We must guard against other instances of those iterators created before we did our fast forward from undoing it by committing their own progress. We do this by ensuring that if a commit would cause a conflicting change then that change get ignored allowing the very first change saved to win instead of the last change.

We add seqNo to the the progress that an iterator commits. Just before an iterator commits, it reads the seqNo of the last commit. If the seqNo stored doesn't match the seqNo it used in its last commit, it knows it would be overwriting someone else's change and so it skips the commit.

