### PR TITLE
Add store.StartAtBeginning method.

### DIFF
--- a/store/api.go
+++ b/store/api.go
@@ -741,6 +741,11 @@ func (s *Store) NamedIteratorForEndpointRollUp(
 		name, endpointId, dur, int(maxFrames), strategy)
 }
 
+// StartAtBeginning removes the stored state for iterators with given names.
+func (s *Store) StartAtBeginning(endpointId interface{}, names ...string) {
+	s.startAtBeginning(endpointId, names)
+}
+
 // LatestByEndpoint returns the latest records for each metric for a
 // given endpoint.
 // LatestByEndpoint appends the records to result in no particular order.

--- a/store/iterators.go
+++ b/store/iterators.go
@@ -174,7 +174,7 @@ func (n *namedIteratorType) Name() string {
 }
 
 func (n *namedIteratorType) Commit() {
-	n.timeSeriesCollection.saveProgress(n.name, n.snapshot())
+	n.timeSeriesCollection.SaveProgress(n.name, n.snapshot())
 }
 
 func (n *namedIteratorType) hasNext() bool {

--- a/store/store.go
+++ b/store/store.go
@@ -124,6 +124,10 @@ func (s *Store) namedIteratorForEndpointRollUp(
 		strategy)
 }
 
+func (s *Store) startAtBeginning(endpointId interface{}, names []string) {
+	s.byApplication[endpointId].StartAtBeginning(names)
+}
+
 func (s *Store) byEndpoint(
 	endpointId interface{},
 	start, end float64,


### PR DESCRIPTION
This PR adds the store.StartAtBeginning method to rewind specific iterators to the very beginning of scotty.  

Scotty must write data to newly added persistent stores from the beginning of scotty data, but scotty remembers the progress of writing to each persistent store. Therefore, if a user removes a persistent store from scotty and later adds the same persistent store back to scotty, scotty will continue writing to that persistent store from where it left off instead of from the very beginning of the scotty data. However, this PR provides a solution to this problem.

This PR povides a method for us to rewind existing iterators to the beginning of scotty data so that even if the user adds back a pre-existing persistent store, scotty can write to that persistent store from the beginning of its data as if the persistent store never existed previously. 

This PR also ensures that first commits win so that we can make guarantees to the caller that once they call store.StartFromBegnning, that action cannot be undone by lingering iterator instances committing their progress.