### PR TITLE
New Gate abstraction.

### DIFF
--- a/lib/gate/api.go
+++ b/lib/gate/api.go
@@ -1,33 +1,69 @@
-// Package gate provides a gate synchronisation primitive.
-// Gates can be either opened or closed.
-// Open gates allow goroutines to proceed; closed gates block goroutines.
+// Package gate provides management of critical sections
 package gate
 
 import (
 	"sync"
 )
 
-// A Gate instance represents a single gate. The zero value is an opened
-// gate ready to use.
+// A Gate instance represents a single critical section of code.
 type Gate struct {
-	lock sync.Mutex
-	// ch is nil if gate is opened. If gate is closed, ch is a non-nil, empty
-	// channel, used to block callers of Await.
-	ch chan struct{}
+	lock               sync.Mutex
+	count              int
+	drainsInProgress   int
+	paused             bool
+	ended              bool
+	zeroReached        sync.Cond
+	noDrainsInProgress sync.Cond
+	wakeup             sync.Cond
 }
 
-// Resume opens this gate.
-func (g *Gate) Resume() {
-	g.resume()
+// New returns a new instance with both the pause and end state cleared.
+func New() *Gate {
+	return _new()
 }
 
-// Pause closes this gate.
+// Caller calls Enter when entering the critical section of code.
+// Enter returns true if caller is granted access to the critical section of
+// code or false otherwise. Enter may also block caller.
+func (g *Gate) Enter() bool {
+	return g.enter()
+}
+
+// If Enter returns true, Caller must call Exit when leaving the critical
+//  section/ of code.
+func (g *Gate) Exit() {
+	g.exit()
+}
+
+// Pause sets the pause state of this instance to true.
+// Pause causes calls to Enter() to block. Once Pause() returns, the caller
+// of pause is guaranteed that no goroutines are in the critical section of
+// code until the next call to Resume().
 func (g *Gate) Pause() {
 	g.pause()
 }
 
-// If this instance is opened, Await returns immediately. Otherwise, Await
-// blocks the caller until this instance is opened.
-func (g *Gate) Await() {
-	g.await()
+// Resume clears the pause state of this instance so that goroutines
+// may once again enter the critical section. If Pause and Resume are called
+// at the same time, Resume blocks until Pause returns before clearing the
+// pause state.
+func (g *Gate) Resume() {
+	g.resume()
+}
+
+// End sets the end state of this instance to true.
+// End causes calls to Enter() to return false. once End() returns, the caller
+// is guaranteed that no goroutines are in the cricial section of code. If
+// both the pause and end state of this instance are set, the end state takes
+// precedence so that Enter() returns false rather than blocking.
+func (g *Gate) End() {
+	g.end()
+}
+
+// Start clears the end state of this instance so that goroutines may
+// once again enter the critical section. If Start and End are called at
+// the same time, Start blocks until End returns before clearing the end
+// state.
+func (g *Gate) Start() {
+	g.start()
 }

--- a/lib/gate/gate_test.go
+++ b/lib/gate/gate_test.go
@@ -1,0 +1,232 @@
+package gate_test
+
+import (
+	"github.com/Symantec/scotty/lib/gate"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPauseResume(t *testing.T) {
+	g := gate.New()
+	criticalSectionCount := newCounter(0)
+	f := func() {
+		if !g.Enter() {
+			t.Error("Expected to enter critical section")
+		}
+		criticalSectionCount.Inc()
+	}
+
+	// Enter critical section 10x
+	runParallel(f, f, f, f, f, f, f, f, f, f)
+
+	pauseF := func() {
+		g.Pause()
+		// When pause is done, no one in critical section
+		if out := criticalSectionCount.Get(); out != 0 {
+			t.Errorf("goroutines still in crit sect: ", out)
+		}
+	}
+
+	f = func() {
+		// Pretend like we are doing something big in critical section
+		time.Sleep(10 * time.Millisecond)
+		criticalSectionCount.Dec()
+		g.Exit()
+	}
+
+	// Pause + exit critical section 10x
+	runParallel(pauseF, f, f, f, f, f, f, f, f, f, f)
+
+	resumed := newCounter(0)
+
+	resumeF := func() {
+		// Pretend like we are doing something big in critical section
+		time.Sleep(10 * time.Millisecond)
+		resumed.Inc()
+		g.Resume()
+	}
+	f = func() {
+		if !g.Enter() {
+			t.Error("Expected to enter critical section")
+		}
+		if resumed.Get() != 1 {
+			t.Error("Resume must be called before entering crit sect")
+		}
+	}
+	runParallel(resumeF, f)
+
+}
+
+func TestEndStart(t *testing.T) {
+	g := gate.New()
+	criticalSectionCount := newCounter(0)
+	f := func() {
+		if !g.Enter() {
+			t.Error("Expected to enter critical section")
+		}
+		criticalSectionCount.Inc()
+	}
+
+	// Enter critical section 10x
+	runParallel(f, f, f, f, f, f, f, f, f, f)
+
+	endF := func() {
+		g.End()
+		// When end is done, no one in critical section
+		if out := criticalSectionCount.Get(); out != 0 {
+			t.Errorf("goroutines still in crit sect: ", out)
+		}
+	}
+
+	f = func() {
+		// Pretend like we are doing something big in critical section
+		time.Sleep(10 * time.Millisecond)
+		criticalSectionCount.Dec()
+		g.Exit()
+	}
+
+	// End + exit critical section 10x
+	runParallel(endF, f, f, f, f, f, f, f, f, f, f)
+
+	if g.Enter() {
+		t.Error("Critical section ended, no one allowed in.")
+	}
+	g.Start()
+	if !g.Enter() {
+		t.Error("Entering critical section expected now")
+	}
+}
+
+func TestConcurrentPauseResume(t *testing.T) {
+	for reps := 0; reps < 10; reps++ {
+		g := gate.New()
+		criticalSectionCount := newCounter(0)
+		stillRunningCount := newCounter(10)
+		f := func() {
+			for {
+				if !g.Enter() {
+					stillRunningCount.Dec()
+					return
+				}
+				criticalSectionCount.Inc()
+				time.Sleep(10 * time.Millisecond)
+				criticalSectionCount.Dec()
+				g.Exit()
+			}
+		}
+		// Start these critical section loops
+		for i := 0; i < 10; i++ {
+			go f()
+		}
+		// Run 5 pairs of pause / resume concurrently. This test is to
+		// ensure that resuming while pausing doesn't block the pause.
+		// If a pause blocks, runParallel will hang.
+		runParallel(
+			g.Pause, g.Resume,
+			g.Pause, g.Resume,
+			g.Pause, g.Resume,
+			g.Pause, g.Resume,
+			g.Pause, g.Resume)
+
+		// We don't know what state we are in now. So we pause
+		g.Pause()
+		if out := criticalSectionCount.Get(); out != 0 {
+			t.Errorf("Goroutines still in crit sect: %d", out)
+		}
+		if out := stillRunningCount.Get(); out != 10 {
+			t.Errorf("Goroutines still in crit sect: %d", out)
+		}
+		g.End()
+		stillRunningCount.WaitOnZero()
+	}
+}
+
+func TestConcurrentStartEnd(t *testing.T) {
+	for reps := 0; reps < 10; reps++ {
+		g := gate.New()
+		stillRunningCount := newCounter(10)
+		f := func() {
+			for {
+				if !g.Enter() {
+					stillRunningCount.Dec()
+					return
+				}
+				time.Sleep(10 * time.Millisecond)
+				g.Exit()
+			}
+		}
+		// Start these critical section loops
+		for i := 0; i < 10; i++ {
+			go f()
+		}
+		// Run 5 pairs of end / start concurrently. This test is to
+		// ensure that starting while ending doesn't block end.
+		// If end blocks, runParallel will hang.
+		runParallel(
+			g.End, g.Start,
+			g.End, g.Start,
+			g.End, g.Start,
+			g.End, g.Start,
+			g.End, g.Start)
+		// We don't know what state we are in now. So we end
+		g.End()
+		stillRunningCount.WaitOnZero()
+	}
+}
+
+func runParallel(fs ...func()) {
+	var wg sync.WaitGroup
+	for _, f := range fs {
+		wg.Add(1)
+		go func(f func()) {
+			defer wg.Done()
+			f()
+		}(f)
+	}
+	wg.Wait()
+}
+
+type counter struct {
+	lock   sync.Mutex
+	isZero sync.Cond
+	value  int
+}
+
+func newCounter(x int) *counter {
+	result := &counter{value: x}
+	result.isZero.L = &result.lock
+	return result
+}
+
+func (c *counter) Get() int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.value
+}
+
+func (c *counter) Inc() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.value++
+	if c.value == 0 {
+		c.isZero.Broadcast()
+	}
+}
+
+func (c *counter) Dec() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.value--
+	if c.value == 0 {
+		c.isZero.Broadcast()
+	}
+}
+
+func (c *counter) WaitOnZero() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for c.value != 0 {
+		c.isZero.Wait()
+	}
+}


### PR DESCRIPTION
The purpose of this abstraction is to guarantee that no goroutines are
in a particular critical section of code at a given time. I use this
when processing config file changes.

Rather than adding scores of getter/setter methods to pstore writers to
accomodate config file changes and worrying about all the possible data
races, I just re-create brand new pstore writers from the old ones.
Doing this is tricky because the old writers must be in a consistent
state before they can be used to create new pstore writers. In
particular, the old pstore writers can't be in the middle of writing
data out, and they can't be in the middle of updating the count of
metrics left to write. Failure to ensure this means subtle data races as
I was seeing earlier in my testing.

By using this gate abstraction, I can ensure that the original writers
are in a safe state before copying them.

This package allows one to annotate critical sections of code and
provides methods to drain goroutines from those critical sections by
disabling them. Once a critical section is drained, an additional method
can re-enable the critical section allowing goroutines in once again.

This package provides similar functionality to a RWMutex as obtaining an
exclusive lock on an RWMutex drains goroutines from critical sections of
code that need a read lock. But unlike RWMutex which panics if locked when
already locked, in this package, disabling and enabling critical sections
of code are idempotent operations. Also with this package, one can arrange
for goroutines to skip over disabled critical sections of code rather than
blocking on them. I use that feature when protecting the critical
section that writes to the pstore because I want goroutines responsible
for writing to eventually exit rather than blocking on a forever
disabled critical section of code.