### PR TITLE
Add store.SetIteratorTo

### DIFF
--- a/store/api.go
+++ b/store/api.go
@@ -746,6 +746,14 @@ func (s *Store) StartAtBeginning(endpointId interface{}, names ...string) {
 	s.startAtBeginning(endpointId, names)
 }
 
+// SetIteratorTo sets the position of future iterators named destName to be
+// the same as future iterators named srcName. Commiting an existing
+// iterator named destName after making this call will have no effect.
+func (s *Store) SetIteratorTo(
+	endpointId interface{}, destName, srcName string) {
+	s.setIteratorTo(endpointId, destName, srcName)
+}
+
 // LatestByEndpoint returns the latest records for each metric for a
 // given endpoint.
 // LatestByEndpoint appends the records to result in no particular order.
@@ -770,6 +778,11 @@ func (s *Store) LatestByPrefixAndEndpointStrategy(
 // same error immediately.
 func (s *Store) VisitAllEndpoints(v Visitor) error {
 	return s.visitAllEndpoints(v)
+}
+
+// Endpoints returns all the endpoints in this store
+func (s *Store) Endpoints() []interface{} {
+	return s.endpoints()
 }
 
 // RegisterMetrics registers metrics under d associated with this Store

--- a/store/seriescollection.go
+++ b/store/seriescollection.go
@@ -215,6 +215,20 @@ func (c *timeSeriesCollectionType) StartAtBeginning(names []string) {
 	}
 }
 
+func (c *timeSeriesCollectionType) SetIteratorTo(destName, srcName string) {
+	if destName == srcName {
+		return
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	srcProgress, ok := c.iterators[srcName]
+	if !ok {
+		delete(c.iterators, destName)
+	} else {
+		c.iterators[destName] = srcProgress
+	}
+}
+
 func (c *timeSeriesCollectionType) SaveProgress(
 	name string, progress *namedIteratorDataType) {
 	c.lock.Lock()

--- a/store/store.go
+++ b/store/store.go
@@ -128,6 +128,11 @@ func (s *Store) startAtBeginning(endpointId interface{}, names []string) {
 	s.byApplication[endpointId].StartAtBeginning(names)
 }
 
+func (s *Store) setIteratorTo(
+	endpointId interface{}, destName, srcName string) {
+	s.byApplication[endpointId].SetIteratorTo(destName, srcName)
+}
+
 func (s *Store) byEndpoint(
 	endpointId interface{},
 	start, end float64,
@@ -159,6 +164,13 @@ func (s *Store) visitAllEndpoints(v Visitor) (err error) {
 		if err = v.Visit(s, endpointId); err != nil {
 			return
 		}
+	}
+	return
+}
+
+func (s *Store) endpoints() (result []interface{}) {
+	for endpointId := range s.byApplication {
+		result = append(result, endpointId)
 	}
 	return
 }


### PR DESCRIPTION
Also add store.Endpoints as on alternative to writing a Visitor
implementation and use latest timestamp instead of earliest
when writing rolled up values.

store.SetIteratorTo provides a way to position iterator A where iterator B is.

If the user changes the roll up span for a pstore writer at runtime,
simply preserving the metrics from the old pstore writer won't do as
changing the roll up span changes how many metric values must be written
out to the pstore. The only reliable way of adjusting the count of
values left to write when roll up span changes is to re-count them.

We re-count values left to write by positioning the value counting
iterator to where the writing iterator is and zeroing out the count
of values left to write. At the next collection of metrics, the counting
iterator will begin counting metrics left to write from where the
writing iterator is. Eventually, the count of metrics left to write will
be correct.

We only need to use this path when the roll up span for a pstore writer
changes. For all other changes, it is fine to just use the values left
to write from the old pstore writer and to keep the counting iterator at
the same location.