### PR TITLE
Sort paths like tricorder does.

### DIFF
--- a/metrics/api.go
+++ b/metrics/api.go
@@ -59,7 +59,7 @@ func (s SimpleList) Index(i int, value *Value) {
 }
 
 func (s SimpleList) Less(i, j int) bool {
-	return s[i].Path < s[j].Path
+	return comparePaths(s[i].Path, s[j].Path) < 0
 }
 
 func (s SimpleList) Swap(i, j int) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -4,12 +4,35 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Symantec/tricorder/go/tricorder/types"
+	"strings"
 	"time"
 )
 
 var (
 	errGroupId = errors.New("metrics: Conflicting Timestamps for group Id.")
 )
+
+func comparePaths(first, second string) int {
+	firstSplits := strings.Split(first, "/")
+	secondSplits := strings.Split(second, "/")
+	flen := len(firstSplits)
+	slen := len(secondSplits)
+	for i := 0; i < flen && i < slen; i++ {
+		if firstSplits[i] < secondSplits[i] {
+			return -1
+		}
+		if firstSplits[i] > secondSplits[i] {
+			return 1
+		}
+	}
+	if flen < slen {
+		return -1
+	}
+	if flen > slen {
+		return 1
+	}
+	return 0
+}
 
 func verifyList(list List) error {
 	length := list.Len()
@@ -19,7 +42,7 @@ func verifyList(list List) error {
 	for i := 0; i < length; i++ {
 		var value Value
 		list.Index(i, &value)
-		if value.Path < lastPathName {
+		if comparePaths(value.Path, lastPathName) < 0 {
 			return errors.New(
 				fmt.Sprintf(
 					"Paths not sorted: '%s' should come before '%s",

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -118,6 +118,26 @@ func TestPathNamesSorted(t *testing.T) {
 	}
 }
 
+func TestPathNamesSortedCorrectly(t *testing.T) {
+	list := metrics.SimpleList{
+		{
+			Path:      "/netstat/foo",
+			Value:     int64(35),
+			TimeStamp: kNow,
+			GroupId:   0,
+		},
+		{
+			Path:      "/netstat.0/foo",
+			Value:     int64(36),
+			TimeStamp: kNow,
+			GroupId:   0,
+		},
+	}
+	if err := metrics.VerifyList(list); err != nil {
+		t.Error("No error expected. Already sorted correctly.")
+	}
+}
+
 func TestSameTimeStampSameGroupOk(t *testing.T) {
 	list := metrics.SimpleList{
 		{


### PR DESCRIPTION
Scotty expects metrics to be sorted lexicographically by name, but tricorder orders differently. Although, tricorder's ordering coincides with lexicographical sorting most of the time, health-agent hits an edge case where the orderings don't coincide.

This fixes scotty so that it expects metrics to be in the same order as tricorder provides them. In particular, tricorder sorts first by the first path component, then by the second path component and so forth. So for tricorder: "netstat/foo" comes before "netstat.0/bar" since netstat.0 comes after netstat. However, this does not coincide with lexicographical sorting since '/' is 2F and '.' is 2E. 