### PR TITLE
Change page queue from FIFO to one favouring older timestamps.

### DIFF
--- a/store/pagequeue.go
+++ b/store/pagequeue.go
@@ -192,12 +192,17 @@ func (s *pageQueueType) RegisterMetrics(d *tricorder.DirectorySpec) (
 	return
 }
 
-// GivePageTo bestows a new page on t.
+// GivePageTo bestows a new page on t. ts is the timestamp of the value
+// being added to t.
 // This call may lock another pageOwnerType instance. To avoid deadlock,
 // caller must not hold a lock on any pageOwnerType instance.
-func (s *pageQueueType) GivePageTo(t pageOwnerType) {
+func (s *pageQueueType) GivePageTo(t pageOwnerType, ts float64) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	fullPage := t.LatestPage()
+	if fullPage != nil {
+		s.pq.Prioritise(fullPage, ts)
+	}
 	var result *pageWithMetaDataType
 	if s.expanding {
 		result = s.pq.NewPage().(*pageWithMetaDataType)


### PR DESCRIPTION
favouring older timestamps is not the same as a FIFO queue. A page
fetched first may contain some timestamps that are more recent than a
page fetched later on if data written to the first page is sparse.