### PR TITLE
Introduce keyedqueue package.

### DIFF
--- a/lib/keyedqueue/api.go
+++ b/lib/keyedqueue/api.go
@@ -1,0 +1,52 @@
+// Package keyedqueue provides a queue with keyed elements allowing elements
+// already on the queue to be easily replaced.
+package keyedqueue
+
+import (
+	"container/list"
+	"sync"
+)
+
+// Element represents a queue element.
+type Element interface {
+	// Key returns the key of this element. Returned key must support
+	// equality.
+	Key() interface{}
+}
+
+// Queue represents a queue of elements. Queue instances are safe to use
+// with multiple goroutines.
+type Queue struct {
+	lock       sync.Mutex
+	elementsOn sync.Cond
+	queue      list.List
+	byKey      map[interface{}]*list.Element
+}
+
+// New returns a brand new, empty queue.
+func New() *Queue {
+	result := &Queue{}
+	result.elementsOn.L = &result.lock
+	result.queue.Init()
+	result.byKey = make(map[interface{}]*list.Element)
+	return result
+}
+
+// Len returns the length of this queue
+func (q *Queue) Len() int {
+	return q.length()
+}
+
+// Add replaces the element in the queue with key matching elementToAdd with
+// elementToAdd. elementToAdd gets the same position in the queue as the
+// element it replaced. If no element with a matching key exists in the queue,
+// Add places elementToAdd at the end of the queue.
+func (q *Queue) Add(elementToAdd Element) {
+	q.add(elementToAdd)
+}
+
+// Remove removes the element at the front of the queue. If queue is empty,
+// Remove blocks.
+func (q *Queue) Remove() Element {
+	return q.remove()
+}

--- a/lib/keyedqueue/keyedqueue.go
+++ b/lib/keyedqueue/keyedqueue.go
@@ -1,0 +1,32 @@
+package keyedqueue
+
+func (q *Queue) length() int {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	return q.queue.Len()
+}
+
+func (q *Queue) add(element Element) {
+	key := element.Key()
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	posit := q.byKey[key]
+	if posit != nil {
+		posit.Value = element
+		return
+	}
+	posit = q.queue.PushBack(element)
+	q.byKey[key] = posit
+	q.elementsOn.Broadcast()
+}
+
+func (q *Queue) remove() Element {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	for q.queue.Len() == 0 {
+		q.elementsOn.Wait()
+	}
+	removedElement := q.queue.Remove(q.queue.Front()).(Element)
+	delete(q.byKey, removedElement.Key())
+	return removedElement
+}

--- a/lib/keyedqueue/keyedqueue_test.go
+++ b/lib/keyedqueue/keyedqueue_test.go
@@ -1,0 +1,79 @@
+package keyedqueue_test
+
+import (
+	"github.com/Symantec/scotty/lib/keyedqueue"
+	. "github.com/smartystreets/goconvey/convey"
+	"sync"
+	"testing"
+	"time"
+)
+
+type element struct {
+	K string
+	V int
+}
+
+func (e *element) Key() interface{} {
+	return e.K
+}
+
+func TestQueue(t *testing.T) {
+
+	Convey("With new queue", t, func() {
+		queue := keyedqueue.New()
+
+		Convey("Remove blocks until element added", func() {
+			var wg sync.WaitGroup
+			var result *element
+			wg.Add(1)
+			go func() {
+				result = queue.Remove().(*element)
+				wg.Done()
+			}()
+			// Wait a bit to help ensure that the call to Remove is blocking.
+			time.Sleep(100 * time.Millisecond)
+			queue.Add(&element{K: "A"})
+			wg.Wait()
+			So(result.K, ShouldEqual, "A")
+		})
+
+		Convey("With A,B,C,D added", func() {
+
+			queue.Add(&element{K: "A"})
+			queue.Add(&element{K: "B"})
+			queue.Add(&element{K: "C"})
+			queue.Add(&element{K: "D"})
+
+			Convey("A,B,C,D removed", func() {
+				So(queue.Len(), ShouldEqual, 4)
+				So(queue.Remove().(*element).K, ShouldEqual, "A")
+				So(queue.Remove().(*element).K, ShouldEqual, "B")
+				So(queue.Remove().(*element).K, ShouldEqual, "C")
+				So(queue.Remove().(*element).K, ShouldEqual, "D")
+				So(queue.Len(), ShouldEqual, 0)
+			})
+
+			Convey("With D' and B' added", func() {
+				queue.Add(&element{K: "D", V: 1})
+				queue.Add(&element{K: "B", V: 1})
+
+				Convey("A, B', C, D' removed", func() {
+					So(queue.Len(), ShouldEqual, 4)
+					res := queue.Remove().(*element)
+					So(res.K, ShouldEqual, "A")
+					So(res.V, ShouldEqual, 0)
+					res = queue.Remove().(*element)
+					So(res.K, ShouldEqual, "B")
+					So(res.V, ShouldEqual, 1)
+					res = queue.Remove().(*element)
+					So(res.K, ShouldEqual, "C")
+					So(res.V, ShouldEqual, 0)
+					res = queue.Remove().(*element)
+					So(res.K, ShouldEqual, "D")
+					So(res.V, ShouldEqual, 1)
+					So(queue.Len(), ShouldEqual, 0)
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
A keyedqueue.Queue instance provides communication between the metric
collection goroutines and the goroutine writing to CIS.

A keyedqueue.Queue instance works like a common go channel except rather than
being strictly FIFO, it allows newer CIS data for a particular machine to
overwrite older CIS data for the same machine that is already in the queue.

This difference between a channel and a keyedqueue.Queue is vital because once
an ordinary buffered channel fills up, it drops any new incoming data for a
machine on the floor keeping the stale data for that machine.  On the other
hand, A keyedqueue.Queue instance keeps only the most recent data for each
machine. Even though a keyedqueue.Queue instance is not bounded in size like
a buffered channel, it is bounded by the number of machines in the fleet.

Even if the goroutine writing to CIS falls behind, the keyedqueue.Queue
instance ensures that it still writes the most recent data available for each
machine.