### PR TITLE
Multiple goroutines to write to CIS

### DIFF
--- a/apps/scotty/cis.go
+++ b/apps/scotty/cis.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"github.com/Symantec/scotty/cis"
+	"github.com/Symantec/scotty/lib/keyedqueue"
+	"github.com/Symantec/tricorder/go/tricorder"
+	"github.com/Symantec/tricorder/go/tricorder/units"
+	"sync"
+	"time"
+)
+
+type splitTimerByKeyType struct {
+	lock               sync.Mutex
+	lastTimeStampByKey map[interface{}]time.Time
+}
+
+func newSplitTimerByKey() *splitTimerByKeyType {
+	return &splitTimerByKeyType{
+		lastTimeStampByKey: make(map[interface{}]time.Time),
+	}
+}
+
+// Split returns the difference between timestamp and last reported
+// timestamp for given key. Split returns false if Split being called for the
+// very first time with given key.
+func (t *splitTimerByKeyType) Split(key interface{}, timeStamp time.Time) (
+	result time.Duration, ok bool) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if lastTimeStamp, exists := t.lastTimeStampByKey[key]; exists {
+		result = timeStamp.Sub(lastTimeStamp)
+		ok = true
+	}
+	t.lastTimeStampByKey[key] = timeStamp
+	return
+}
+
+type cisWriterMetricsType struct {
+	LastWriteError   string
+	SuccessfulWrites uint64
+	TotalWrites      uint64
+}
+
+func (c *cisWriterMetricsType) FailedWrites() uint64 {
+	return c.TotalWrites - c.SuccessfulWrites
+}
+
+type cisWriterMetricsManagerType struct {
+	lock    sync.Mutex
+	metrics cisWriterMetricsType
+}
+
+func newCISWriterMetricsManager() *cisWriterMetricsManagerType {
+	return &cisWriterMetricsManagerType{}
+}
+
+func (c *cisWriterMetricsManagerType) LogWrite(err error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.metrics.TotalWrites++
+	if err != nil {
+		c.metrics.LastWriteError = err.Error()
+	} else {
+		c.metrics.SuccessfulWrites++
+	}
+}
+
+func (c *cisWriterMetricsManagerType) Get(metrics *cisWriterMetricsType) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	*metrics = c.metrics
+}
+
+func createCISWriters(
+	cisQueue *keyedqueue.Queue,
+	cisClient *cis.Client,
+	goroutineCount uint) (err error) {
+	if err = tricorder.RegisterMetric(
+		"cis/queueSize",
+		cisQueue.Len,
+		units.None,
+		"Length of queue"); err != nil {
+		return
+	}
+	timeBetweenWritesDist := tricorder.NewGeometricBucketer(1, 100000.0).NewCumulativeDistribution()
+	if err = tricorder.RegisterMetric(
+		"cis/timeBetweenWrites",
+		timeBetweenWritesDist,
+		units.Second,
+		"elapsed time between CIS updates"); err != nil {
+		return
+	}
+	writeTimesDist := tricorder.NewGeometricBucketer(1, 100000.0).NewCumulativeDistribution()
+	if err = tricorder.RegisterMetric(
+		"cis/writeTimes",
+		writeTimesDist,
+		units.Millisecond,
+		"elapsed time between CIS updates"); err != nil {
+		return
+	}
+	payloadSizeDist := tricorder.NewGeometricBucketer(1, 1000000000.0).NewCumulativeDistribution()
+	if err = tricorder.RegisterMetric(
+		"cis/payloadSizes",
+		payloadSizeDist,
+		units.None,
+		"Payload sizes"); err != nil {
+		return
+	}
+
+	metricsManager := newCISWriterMetricsManager()
+	var cisWriterMetrics cisWriterMetricsType
+	cisWriterMetricsGroup := tricorder.NewGroup()
+	cisWriterMetricsGroup.RegisterUpdateFunc(func() time.Time {
+		metricsManager.Get(&cisWriterMetrics)
+		return time.Now()
+	})
+
+	if err = tricorder.RegisterMetricInGroup(
+		"cis/lastWriteError",
+		&cisWriterMetrics.LastWriteError,
+		cisWriterMetricsGroup,
+		units.None,
+		"Last CIS write error"); err != nil {
+		return
+	}
+	if err = tricorder.RegisterMetricInGroup(
+		"cis/successfulWrites",
+		&cisWriterMetrics.SuccessfulWrites,
+		cisWriterMetricsGroup,
+		units.None,
+		"Successful write count"); err != nil {
+		return
+	}
+	if err = tricorder.RegisterMetricInGroup(
+		"cis/totalWrites",
+		&cisWriterMetrics.TotalWrites,
+		cisWriterMetricsGroup,
+		units.None,
+		"total write count"); err != nil {
+		return
+	}
+	if err = tricorder.RegisterMetricInGroup(
+		"cis/failedWrites",
+		cisWriterMetrics.FailedWrites,
+		cisWriterMetricsGroup,
+		units.None,
+		"failed write count"); err != nil {
+		return
+	}
+
+	splitTimerByKey := newSplitTimerByKey()
+
+	for i := uint(0); i < goroutineCount; i++ {
+		// CIS loop
+		go func() {
+			for {
+				stat := cisQueue.Remove().(*cis.Stats)
+				key := stat.Key()
+				if elapsed, ok := splitTimerByKey.Split(key, stat.TimeStamp); ok {
+					timeBetweenWritesDist.Add(elapsed)
+				}
+				writeStartTime := time.Now()
+				writeInfo, err := cisClient.Write(stat)
+				if err == nil {
+					writeTimesDist.Add(time.Since(writeStartTime))
+					payloadSizeDist.Add(float64(writeInfo.PayloadSize))
+				}
+				metricsManager.LogWrite(err)
+			}
+		}()
+	}
+	return
+}

--- a/apps/scotty/collect.go
+++ b/apps/scotty/collect.go
@@ -38,6 +38,10 @@ var (
 		"cisRegex",
 		"",
 		"If provided, host must match regex for scotty to send its data to CIS")
+	fCisConcurrency = flag.Uint(
+		"cisConcurrency",
+		10,
+		"Number of goroutines writing to CIS")
 )
 
 type byHostName messages.ErrorList
@@ -345,77 +349,6 @@ func startCollector(
 	}()
 
 	if cisQueue != nil && cisClient != nil {
-		if err := tricorder.RegisterMetric(
-			"cis/queueSize",
-			cisQueue.Len,
-			units.None,
-			"Length of queue"); err != nil {
-			log.Fatal(err)
-		}
-		timeBetweenWritesDist := tricorder.NewGeometricBucketer(1, 100000.0).NewCumulativeDistribution()
-		if err := tricorder.RegisterMetric(
-			"cis/timeBetweenWrites",
-			timeBetweenWritesDist,
-			units.Second,
-			"elapsed time between CIS updates"); err != nil {
-			log.Fatal(err)
-		}
-		writeTimesDist := tricorder.NewGeometricBucketer(1, 100000.0).NewCumulativeDistribution()
-		if err := tricorder.RegisterMetric(
-			"cis/writeTimes",
-			writeTimesDist,
-			units.Millisecond,
-			"elapsed time between CIS updates"); err != nil {
-			log.Fatal(err)
-		}
-		var lastWriteError string
-		if err := tricorder.RegisterMetric(
-			"cis/lastWriteError",
-			&lastWriteError,
-			units.None,
-			"Last CIS write error"); err != nil {
-			log.Fatal(err)
-		}
-		var successfulWrites uint64
-		if err := tricorder.RegisterMetric(
-			"cis/successfulWrites",
-			&successfulWrites,
-			units.None,
-			"Successful write count"); err != nil {
-			log.Fatal(err)
-		}
-		var totalWrites uint64
-		if err := tricorder.RegisterMetric(
-			"cis/totalWrites",
-			&totalWrites,
-			units.None,
-			"total write count"); err != nil {
-			log.Fatal(err)
-		}
-
-		// CIS loop
-		go func() {
-			lastTimeStampByKey := make(map[interface{}]time.Time)
-			for {
-				stat := cisQueue.Remove().(*cis.Stats)
-				key := stat.Key()
-				if lastTimeStamp, ok := lastTimeStampByKey[key]; ok {
-					timeBetweenWritesDist.Add(stat.TimeStamp.Sub(lastTimeStamp))
-				} else {
-					// On first write, just use time elapsed since start of
-					// scotty
-					timeBetweenWritesDist.Add(time.Now().Sub(programStartTime))
-				}
-				lastTimeStampByKey[key] = stat.TimeStamp
-				writeStartTime := time.Now()
-				if err := cisClient.Write(stat); err != nil {
-					lastWriteError = err.Error()
-				} else {
-					successfulWrites++
-				}
-				totalWrites++
-				writeTimesDist.Add(time.Since(writeStartTime))
-			}
-		}()
+		createCISWriters(cisQueue, cisClient, *fCisConcurrency)
 	}
 }

--- a/cis/api.go
+++ b/cis/api.go
@@ -6,6 +6,12 @@ import (
 	"time"
 )
 
+// WriteInfo contains info of a single CIS write
+type WriteInfo struct {
+	// The size of the payload written
+	PayloadSize uint64
+}
+
 // PackageEntry represents a single package on a machine
 type PackageEntry struct {
 	// Package name e.g python3.4
@@ -64,6 +70,6 @@ func NewClient(config *Config) (*Client, error) {
 }
 
 // Write writes data to CIS
-func (c *Client) Write(stats *Stats) error {
+func (c *Client) Write(stats *Stats) (WriteInfo, error) {
 	return c.write(stats)
 }

--- a/cis/client.go
+++ b/cis/client.go
@@ -13,7 +13,7 @@ var (
 	replacer = strings.NewReplacer(".", "_")
 )
 
-func (c *Client) write(stats *Stats) error {
+func (c *Client) write(stats *Stats) (info WriteInfo, err error) {
 
 	type versionSizeType struct {
 		Version string `json:"version"`
@@ -39,22 +39,24 @@ func (c *Client) write(stats *Stats) error {
 
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)
-	if err := encoder.Encode(jsonToEncode); err != nil {
-		return err
+	if err = encoder.Encode(jsonToEncode); err != nil {
+		return
 	}
+	payload := buffer.Len()
 	// TODO: Maybe get rid of all the diagnostics in the error messages
 	bufferStr := buffer.String()
 	url := fmt.Sprintf("%s/aws/instances/%s", c.endpoint, stats.InstanceId)
 	resp, err := http.Post(url, "application/json", buffer)
 	if err != nil {
-		return errors.New(err.Error() + ": " + url + ": " + bufferStr)
-		//		return err
+		err = errors.New(err.Error() + ": " + url + ": " + bufferStr)
+		return
 	}
 	defer resp.Body.Close()
 	// Do this way in case we get 201
 	if resp.StatusCode/100 != 2 {
-		return errors.New(resp.Status + ": " + url + ": " + bufferStr)
-		// return errors.New(resp.Status)
+		err = errors.New(resp.Status + ": " + url + ": " + bufferStr)
+		// err = errors.New(resp.Status)
 	}
-	return nil
+	info.PayloadSize = uint64(payload)
+	return
 }


### PR DESCRIPTION
This PR does the following:

1. Have multiple goroutines writing to CIS
2. Remove race conditions with logging metrics among multiple goroutines
3. Keep distribution of payload size per write.
4. Move CIS stuff in scotty main into a separate file.
