### PR TITLE
DON'T MERGE: Report midpoint time of intervals when queried.

### DIFF
--- a/tsdb/aggregators/aggregator_test.go
+++ b/tsdb/aggregators/aggregator_test.go
@@ -23,22 +23,22 @@ func TestLinearInterpolation(t *testing.T) {
 	aggregator.Add(nil)
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{1000.0, 31.25},
-		{1200.0, 28.125},
-		{1400.0, 25.0},
-		{1600.0, 50.0},
-		{1800.0, 75.0}}
+		{1100.0, 31.25},
+		{1300.0, 28.125},
+		{1500.0, 25.0},
+		{1700.0, 50.0},
+		{1900.0, 75.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 	aggregator.Add(tsdb.TimeSeries{
 		{1200.0, 40.0},
 		{1600.0, 46.0}})
 	aggregated = aggregator.Aggregate()
 	expected = tsdb.TimeSeries{
-		{1000.0, 31.25},
-		{1200.0, 34.0625},
-		{1400.0, 34.0},
-		{1600.0, 48.0},
-		{1800.0, 75.0}}
+		{1100.0, 31.25},
+		{1300.0, 34.0625},
+		{1500.0, 34.0},
+		{1700.0, 48.0},
+		{1900.0, 75.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -60,10 +60,10 @@ func TestRate(t *testing.T) {
 		{1800.0, 52000.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{1000.0, 195.0},
-		{1200.0, 97.5},
-		{1400.0, 0.0},
-		{1600.0, 0.0}}
+		{1100.0, 195.0},
+		{1300.0, 97.5},
+		{1500.0, 0.0},
+		{1700.0, 0.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -84,10 +84,10 @@ func TestRateNoReset(t *testing.T) {
 		{1800.0, 52000.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{1000.0, 195.0},
-		{1200.0, 97.5},
-		{1400.0, 250.0},
-		{1600.0, 322.5}}
+		{1100.0, 195.0},
+		{1300.0, 97.5},
+		{1500.0, 250.0},
+		{1700.0, 322.5}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -108,10 +108,10 @@ func TestRateNoResetOrMax(t *testing.T) {
 		{1800.0, 52000.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{1000.0, 195.0},
-		{1200.0, 0.0},
-		{1400.0, 250.0},
-		{1600.0, 0.0}}
+		{1100.0, 195.0},
+		{1300.0, 0.0},
+		{1500.0, 250.0},
+		{1700.0, 0.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -132,10 +132,10 @@ func TestRateNoCounter(t *testing.T) {
 		{1800.0, 52000.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{1000.0, 195.0},
-		{1200.0, -230.0},
-		{1400.0, 250.0},
-		{1600.0, -5.0}}
+		{1100.0, 195.0},
+		{1300.0, -230.0},
+		{1500.0, 250.0},
+		{1700.0, -5.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -154,10 +154,10 @@ func TestRateMissingValues(t *testing.T) {
 		{1800.0, 52000.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{1000.0, 65.0},
-		{1200.0, 65.0},
-		{1400.0, 65.0},
-		{1600.0, 15.0}}
+		{1100.0, 65.0},
+		{1300.0, 65.0},
+		{1500.0, 65.0},
+		{1700.0, 15.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 
 	aggregator = aggregators.New(
@@ -173,7 +173,7 @@ func TestRateMissingValues(t *testing.T) {
 		{1600.0, 49000.0}})
 	aggregated = aggregator.Aggregate()
 	expected = tsdb.TimeSeries{
-		{1400.0, 195.0}}
+		{1500.0, 195.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -201,10 +201,10 @@ func TestCount(t *testing.T) {
 		{2019.0, 1.3}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{1200.0, 2.0},
-		{1400.0, 2.0},
-		{1600.0, 0.0},
-		{1800.0, 2.0}}
+		{1300.0, 2.0},
+		{1500.0, 2.0},
+		{1700.0, 0.0},
+		{1900.0, 2.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -234,10 +234,10 @@ func TestAverage(t *testing.T) {
 	aggregator.Add(nil)
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{1000.0, 48.5},
-		{1400.0, 1025.0},
-		{1600.0, 99.0},
-		{1800.0, 149.0}}
+		{1100.0, 48.5},
+		{1500.0, 1025.0},
+		{1700.0, 99.0},
+		{1900.0, 149.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -268,11 +268,11 @@ func TestAverageZero(t *testing.T) {
 	aggregator.Add(nil)
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{1000.0, 12.125},
-		{1200.0, 0.0},
-		{1400.0, 768.75},
-		{1600.0, 24.75},
-		{1800.0, 74.5}}
+		{1100.0, 12.125},
+		{1300.0, 0.0},
+		{1500.0, 768.75},
+		{1700.0, 24.75},
+		{1900.0, 74.5}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -302,10 +302,10 @@ func TestAverageMax(t *testing.T) {
 	aggregator.Add(nil)
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{1000.0, 54.0},
-		{1400.0, 1043.5},
-		{1600.0, 99.0},
-		{1800.0, 150.0}}
+		{1100.0, 54.0},
+		{1500.0, 1043.5},
+		{1700.0, 99.0},
+		{1900.0, 150.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -335,10 +335,10 @@ func TestMaxAverage(t *testing.T) {
 	aggregator.Add(nil)
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{1000.0, 48.5},
-		{1400.0, 2025.0},
-		{1600.0, 99.0},
-		{1800.0, 200.0}}
+		{1100.0, 48.5},
+		{1500.0, 2025.0},
+		{1700.0, 99.0},
+		{1900.0, 200.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -368,10 +368,10 @@ func TestSumAverage(t *testing.T) {
 	aggregator.Add(nil)
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{1000.0, 48.5},
-		{1400.0, 3075.0},
-		{1600.0, 99.0},
-		{1800.0, 298.0}}
+		{1100.0, 48.5},
+		{1500.0, 3075.0},
+		{1700.0, 99.0},
+		{1900.0, 298.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -389,7 +389,7 @@ func TestAverageStrangeStartAndEnd(t *testing.T) {
 		{1401.0, 20.0}, {1599.0, 30.0},
 		{1836.0, 98.0}})
 	aggregated := aggregator.Aggregate()
-	expected := tsdb.TimeSeries{{1400.0, 25.0}}
+	expected := tsdb.TimeSeries{{1500.0, 25.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 
@@ -427,8 +427,8 @@ func TestNegativeStart(t *testing.T) {
 		{29027.0, 43.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
-		{-10000.0, -5.0},
-		{0, 5.0}}
+		{-5000.0, -5.0},
+		{5000.0, 5.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 }
 

--- a/tsdb/aggregators/downsample.go
+++ b/tsdb/aggregators/downsample.go
@@ -36,7 +36,7 @@ func (p *downSamplePolicyType) IndexOf(ts float64) int {
 
 // TSOf converts given index to a timestamp
 func (p *downSamplePolicyType) TSOf(index int) float64 {
-	return float64(p.start + int64(index)*p.downSampleSize)
+	return float64(p.start + int64(index)*p.downSampleSize + p.downSampleSize/2)
 }
 
 // DownSampleSize returns the down sample size in seconds.

--- a/tsdb/aggregators/specific_aggregator_test.go
+++ b/tsdb/aggregators/specific_aggregator_test.go
@@ -81,7 +81,7 @@ func (a *aggregatorTesterType) Verify(t *testing.T) {
 		if !a.expected[i].Valid {
 			continue
 		}
-		if aggIdx >= len(aggregatedTimeSeries) || aggregatedTimeSeries[aggIdx].Ts != float64(i)*kMaxSampleSize {
+		if aggIdx >= len(aggregatedTimeSeries) || aggregatedTimeSeries[aggIdx].Ts != float64(i)*kMaxSampleSize+kMaxSampleSize/2 {
 			t.Error(
 				"Timestamps don't match. No value was emitted when one was expected or the other way around. Or maybe the Len() function is wrong.")
 			return

--- a/tsdbimpl/tsdbimpl_test.go
+++ b/tsdbimpl/tsdbimpl_test.go
@@ -116,7 +116,7 @@ func TestAPI(t *testing.T) {
 		Data: []tsdb.TaggedTimeSeries{
 			{
 				Values: tsdb.TimeSeries{
-					{500.0, 55.5}, {520.0, 57.5}, {540.0, 59.0},
+					{510.0, 55.5}, {530.0, 57.5}, {550.0, 59.0},
 				},
 			},
 		},
@@ -167,7 +167,7 @@ func TestAPI(t *testing.T) {
 		Data: []tsdb.TaggedTimeSeries{
 			{
 				Values: tsdb.TimeSeries{
-					{700.0, 80.0}, {800.0, 100.0},
+					{710.0, 80.0}, {810.0, 100.0},
 				},
 			},
 		},
@@ -232,7 +232,7 @@ func TestAPI(t *testing.T) {
 					HostName: "host1",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 35.5}, {520.0, 37.5}, {540.0, 39.0},
+					{510.0, 35.5}, {530.0, 37.5}, {550.0, 39.0},
 				},
 			},
 			{
@@ -240,7 +240,7 @@ func TestAPI(t *testing.T) {
 					HostName: "host2",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 55.5}, {520.0, 57.5}, {540.0, 59.0},
+					{510.0, 55.5}, {530.0, 57.5}, {550.0, 59.0},
 				},
 			},
 			{
@@ -248,7 +248,7 @@ func TestAPI(t *testing.T) {
 					HostName: "host3",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 75.5}, {520.0, 77.5}, {540.0, 79.0},
+					{510.0, 75.5}, {530.0, 77.5}, {550.0, 79.0},
 				},
 			},
 		},
@@ -318,7 +318,7 @@ func TestAPI(t *testing.T) {
 					AppName: "AnApp",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 50.5}, {520.0, 52.5}, {540.0, 54.0},
+					{510.0, 50.5}, {530.0, 52.5}, {550.0, 54.0},
 				},
 			},
 			{
@@ -326,7 +326,7 @@ func TestAPI(t *testing.T) {
 					AppName: "AnotherApp",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 60.5}, {520.0, 62.5}, {540.0, 64},
+					{510.0, 60.5}, {530.0, 62.5}, {550.0, 64},
 				},
 			},
 		},
@@ -368,7 +368,7 @@ func TestAPI(t *testing.T) {
 					AppName:  "AnApp",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 30.5}, {520.0, 32.5}, {540.0, 34.0},
+					{510.0, 30.5}, {530.0, 32.5}, {550.0, 34.0},
 				},
 			},
 			{
@@ -377,7 +377,7 @@ func TestAPI(t *testing.T) {
 					AppName:  "AnotherApp",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 40.5}, {520.0, 42.5}, {540.0, 44.0},
+					{510.0, 40.5}, {530.0, 42.5}, {550.0, 44.0},
 				},
 			},
 			{
@@ -386,7 +386,7 @@ func TestAPI(t *testing.T) {
 					AppName:  "AnApp",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 50.5}, {520.0, 52.5}, {540.0, 54.0},
+					{510.0, 50.5}, {530.0, 52.5}, {550.0, 54.0},
 				},
 			},
 			{
@@ -395,7 +395,7 @@ func TestAPI(t *testing.T) {
 					AppName:  "AnotherApp",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 60.5}, {520.0, 62.5}, {540.0, 64.0},
+					{510.0, 60.5}, {530.0, 62.5}, {550.0, 64.0},
 				},
 			},
 			{
@@ -404,7 +404,7 @@ func TestAPI(t *testing.T) {
 					AppName:  "AnApp",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 70.5}, {520.0, 72.5}, {540.0, 74.0},
+					{510.0, 70.5}, {530.0, 72.5}, {550.0, 74.0},
 				},
 			},
 			{
@@ -413,7 +413,7 @@ func TestAPI(t *testing.T) {
 					AppName:  "AnotherApp",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 80.5}, {520.0, 82.5}, {540.0, 84.0},
+					{510.0, 80.5}, {530.0, 82.5}, {550.0, 84.0},
 				},
 			},
 		},
@@ -494,7 +494,7 @@ func TestAPI(t *testing.T) {
 					AppName:  "AnApp",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 50.5}, {520.0, 52.5}, {540.0, 54.0},
+					{510.0, 50.5}, {530.0, 52.5}, {550.0, 54.0},
 				},
 			},
 			{
@@ -503,7 +503,7 @@ func TestAPI(t *testing.T) {
 					AppName:  "AnApp",
 				},
 				Values: tsdb.TimeSeries{
-					{500.0, 70.5}, {520.0, 72.5}, {540.0, 74.0},
+					{510.0, 70.5}, {530.0, 72.5}, {550.0, 74.0},
 				},
 			},
 		},
@@ -546,7 +546,7 @@ func TestAPI(t *testing.T) {
 		Data: []tsdb.TaggedTimeSeries{
 			{
 				Values: tsdb.TimeSeries{
-					{500.0, 60.5}, {520.0, 62.5}, {540.0, 64.0},
+					{510.0, 60.5}, {530.0, 62.5}, {550.0, 64.0},
 				},
 			},
 		},


### PR DESCRIPTION
This PR changes scotty to report the midpoint times instead of the start times as you suggested.

However, I'd like to discuss more before we merge it.