### PR TITLE
Change rolling up values for influx OpenTSDB.

### DIFF
--- a/tsdb/aggregators/aggregator.go
+++ b/tsdb/aggregators/aggregator.go
@@ -63,12 +63,12 @@ type downSampleType struct {
 }
 
 func computeClampStart(start float64, downSample float64) float64 {
-	quotient := start / downSample
+	quotient := start/downSample + 0.5
 	timeSliceId := math.Floor(quotient)
 	if timeSliceId == quotient {
-		return timeSliceId * downSample
+		return (timeSliceId - 0.5) * downSample
 	}
-	return (timeSliceId + 1.0) * downSample
+	return (timeSliceId + 0.5) * downSample
 }
 
 func _new(

--- a/tsdb/aggregators/aggregator_test.go
+++ b/tsdb/aggregators/aggregator_test.go
@@ -9,17 +9,17 @@ import (
 
 func TestLinearInterpolation(t *testing.T) {
 	aggregator := aggregators.New(
-		1000.0,
-		2000.0,
+		900.0,
+		1900.0,
 		aggregators.Avg,
 		200.0,
 		aggregators.Avg,
 		aggregators.None,
 		nil)
 	aggregator.Add(tsdb.TimeSeries{
-		{1000.0, 31.0}, {1030.0, 31.5}, {1199.999, 31.25},
-		{1401.0, 20.0}, {1599.0, 30.0},
-		{1836.0, 75.0}})
+		{900.0, 31.0}, {930.0, 31.5}, {1099.999, 31.25},
+		{1301.0, 20.0}, {1499.0, 30.0},
+		{1736.0, 75.0}})
 	aggregator.Add(nil)
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
@@ -30,8 +30,8 @@ func TestLinearInterpolation(t *testing.T) {
 		{1800.0, 75.0}}
 	assertValueDeepEqual(t, expected, aggregated)
 	aggregator.Add(tsdb.TimeSeries{
-		{1200.0, 40.0},
-		{1600.0, 46.0}})
+		{1100.0, 40.0},
+		{1500.0, 46.0}})
 	aggregated = aggregator.Aggregate()
 	expected = tsdb.TimeSeries{
 		{1000.0, 31.25},
@@ -44,8 +44,8 @@ func TestLinearInterpolation(t *testing.T) {
 
 func TestRate(t *testing.T) {
 	aggregator := aggregators.New(
-		1000.0,
-		2000.0,
+		900.0,
+		1900.0,
 		aggregators.Avg,
 		200.0,
 		aggregators.Avg,
@@ -53,11 +53,11 @@ func TestRate(t *testing.T) {
 		&aggregators.RateSpec{
 			Counter: true, CounterMax: 65500.0, ResetValue: 200.0})
 	aggregator.Add(tsdb.TimeSeries{
-		{1000.0, 10000.0},
-		{1200.0, 49000.0},
-		{1400.0, 3000.0},
-		{1600.0, 53000.0},
-		{1800.0, 52000.0}})
+		{900.0, 10000.0},
+		{1100.0, 49000.0},
+		{1300.0, 3000.0},
+		{1500.0, 53000.0},
+		{1700.0, 52000.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
 		{1000.0, 195.0},
@@ -69,19 +69,19 @@ func TestRate(t *testing.T) {
 
 func TestRateNoReset(t *testing.T) {
 	aggregator := aggregators.New(
-		1000.0,
-		2000.0,
+		900.0,
+		1900.0,
 		aggregators.Avg,
 		200.0,
 		aggregators.Avg,
 		aggregators.NaN,
 		&aggregators.RateSpec{Counter: true, CounterMax: 65500.0})
 	aggregator.Add(tsdb.TimeSeries{
-		{1000.0, 10000.0},
-		{1200.0, 49000.0},
-		{1400.0, 3000.0},
-		{1600.0, 53000.0},
-		{1800.0, 52000.0}})
+		{900.0, 10000.0},
+		{1100.0, 49000.0},
+		{1300.0, 3000.0},
+		{1500.0, 53000.0},
+		{1700.0, 52000.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
 		{1000.0, 195.0},
@@ -93,19 +93,19 @@ func TestRateNoReset(t *testing.T) {
 
 func TestRateNoResetOrMax(t *testing.T) {
 	aggregator := aggregators.New(
-		1000.0,
-		2000.0,
+		900.0,
+		1900.0,
 		aggregators.Avg,
 		200.0,
 		aggregators.Avg,
 		aggregators.NaN,
 		&aggregators.RateSpec{Counter: true})
 	aggregator.Add(tsdb.TimeSeries{
-		{1000.0, 10000.0},
-		{1200.0, 49000.0},
-		{1400.0, 3000.0},
-		{1600.0, 53000.0},
-		{1800.0, 52000.0}})
+		{900.0, 10000.0},
+		{1100.0, 49000.0},
+		{1300.0, 3000.0},
+		{1500.0, 53000.0},
+		{1700.0, 52000.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
 		{1000.0, 195.0},
@@ -117,19 +117,19 @@ func TestRateNoResetOrMax(t *testing.T) {
 
 func TestRateNoCounter(t *testing.T) {
 	aggregator := aggregators.New(
-		1000.0,
-		2000.0,
+		900.0,
+		1900.0,
 		aggregators.Avg,
 		200.0,
 		aggregators.Avg,
 		aggregators.NaN,
 		&aggregators.RateSpec{})
 	aggregator.Add(tsdb.TimeSeries{
-		{1000.0, 10000.0},
-		{1200.0, 49000.0},
-		{1400.0, 3000.0},
-		{1600.0, 53000.0},
-		{1800.0, 52000.0}})
+		{900.0, 10000.0},
+		{1100.0, 49000.0},
+		{1300.0, 3000.0},
+		{1500.0, 53000.0},
+		{1700.0, 52000.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
 		{1000.0, 195.0},
@@ -141,17 +141,17 @@ func TestRateNoCounter(t *testing.T) {
 
 func TestRateMissingValues(t *testing.T) {
 	aggregator := aggregators.New(
-		1000.0,
-		2000.0,
+		900.0,
+		1900.0,
 		aggregators.Avg,
 		200.0,
 		aggregators.Avg,
 		aggregators.NaN,
 		&aggregators.RateSpec{})
 	aggregator.Add(tsdb.TimeSeries{
-		{1000.0, 10000.0},
-		{1600.0, 49000.0},
-		{1800.0, 52000.0}})
+		{900.0, 10000.0},
+		{1500.0, 49000.0},
+		{1700.0, 52000.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
 		{1000.0, 65.0},
@@ -161,16 +161,16 @@ func TestRateMissingValues(t *testing.T) {
 	assertValueDeepEqual(t, expected, aggregated)
 
 	aggregator = aggregators.New(
-		1000.0,
-		2000.0,
+		900.0,
+		1900.0,
 		aggregators.Avg,
 		200.0,
 		aggregators.Avg,
 		aggregators.NaN,
 		&aggregators.RateSpec{})
 	aggregator.Add(tsdb.TimeSeries{
-		{1400.0, 10000.0},
-		{1600.0, 49000.0}})
+		{1300.0, 10000.0},
+		{1500.0, 49000.0}})
 	aggregated = aggregator.Aggregate()
 	expected = tsdb.TimeSeries{
 		{1400.0, 195.0}}
@@ -179,26 +179,26 @@ func TestRateMissingValues(t *testing.T) {
 
 func TestCount(t *testing.T) {
 	aggregator := aggregators.New(
-		1043.0,
-		2021.0,
+		943.0,
+		1921.0,
 		aggregators.Count,
 		200.0,
 		aggregators.Avg,
 		aggregators.NaN,
 		nil)
 	aggregator.Add(tsdb.TimeSeries{
-		{1043.0, 42.0}, {1044.0, 54.0}, {1199.999, 49.5},
-		{1200.0, 35.0},
-		{1401.0, 20.0}, {1599.0, 30.0},
-		{1836.0, 98.0},
-		{2019.0, 1.3}})
+		{943.0, 42.0}, {944.0, 54.0}, {1099.999, 49.5},
+		{1100.0, 35.0},
+		{1301.0, 20.0}, {1499.0, 30.0},
+		{1736.0, 98.0},
+		{1919.0, 1.3}})
 	aggregator.Add(nil)
 	aggregator.Add(tsdb.TimeSeries{
-		{1043.0, 42.0}, {1044.0, 54.0}, {1199.999, 49.5},
-		{1200.0, 53.0},
-		{1401.0, 20.0}, {1599.0, 30.0},
-		{1836.0, 98.0},
-		{2019.0, 1.3}})
+		{943.0, 42.0}, {944.0, 54.0}, {1099.999, 49.5},
+		{1100.0, 53.0},
+		{1301.0, 20.0}, {1499.0, 30.0},
+		{1736.0, 98.0},
+		{1919.0, 1.3}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
 		{1200.0, 2.0},
@@ -210,27 +210,27 @@ func TestCount(t *testing.T) {
 
 func TestAverage(t *testing.T) {
 	aggregator := aggregators.New(
-		1000.0,
-		2000.0,
+		900.0,
+		1900.0,
 		aggregators.Avg,
 		200.0,
 		aggregators.Avg,
 		aggregators.NaN,
 		nil)
 	aggregator.Add(tsdb.TimeSeries{
-		{1000.0, 42.0}, {1030.0, 54.0}, {1199.999, 49.5},
-		{1401.0, 20.0}, {1599.0, 30.0},
-		{1836.0, 98.0}})
+		{900.0, 42.0}, {930.0, 54.0}, {1099.999, 49.5},
+		{1301.0, 20.0}, {1499.0, 30.0},
+		{1736.0, 98.0}})
 	aggregator.Add(tsdb.TimeSeries{
-		{1500.0, 1025.0},
-		{1600.0, 99.0},
-		{1800.0, 198.0}, {1801.0, 202.0}, {1999.1, 200.0}})
+		{1400.0, 1025.0},
+		{1500.0, 99.0},
+		{1700.0, 198.0}, {1701.0, 202.0}, {1899.1, 200.0}})
 	aggregator.Add(tsdb.TimeSeries{
-		{1400.0, 1975.0},
-		{1450.0, 2000.0},
-		{1599.0, 2025.0},
-		{1599.1, 2050.0},
-		{1599.2, 2075.0}})
+		{1300.0, 1975.0},
+		{1350.0, 2000.0},
+		{1499.0, 2025.0},
+		{1499.1, 2050.0},
+		{1499.2, 2075.0}})
 	aggregator.Add(nil)
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
@@ -243,27 +243,27 @@ func TestAverage(t *testing.T) {
 
 func TestAverageZero(t *testing.T) {
 	aggregator := aggregators.New(
-		1000.0,
-		2000.0,
+		900.0,
+		1900.0,
 		aggregators.Avg,
 		200.0,
 		aggregators.Avg,
 		aggregators.Zero,
 		nil)
 	aggregator.Add(tsdb.TimeSeries{
-		{1000.0, 42.0}, {1030.0, 54.0}, {1199.999, 49.5},
-		{1401.0, 20.0}, {1599.0, 30.0},
-		{1836.0, 98.0}})
+		{900.0, 42.0}, {930.0, 54.0}, {1099.999, 49.5},
+		{1301.0, 20.0}, {1499.0, 30.0},
+		{1736.0, 98.0}})
 	aggregator.Add(tsdb.TimeSeries{
-		{1500.0, 1025.0},
-		{1600.0, 99.0},
-		{1800.0, 198.0}, {1801.0, 202.0}, {1999.1, 200.0}})
+		{1400.0, 1025.0},
+		{1500.0, 99.0},
+		{1700.0, 198.0}, {1701.0, 202.0}, {1899.1, 200.0}})
 	aggregator.Add(tsdb.TimeSeries{
-		{1400.0, 1975.0},
-		{1450.0, 2000.0},
-		{1599.0, 2025.0},
-		{1599.1, 2050.0},
-		{1599.2, 2075.0}})
+		{1300.0, 1975.0},
+		{1350.0, 2000.0},
+		{1499.0, 2025.0},
+		{1499.1, 2050.0},
+		{1499.2, 2075.0}})
 	// Counts as all zeros
 	aggregator.Add(nil)
 	aggregated := aggregator.Aggregate()
@@ -278,27 +278,27 @@ func TestAverageZero(t *testing.T) {
 
 func TestAverageMax(t *testing.T) {
 	aggregator := aggregators.New(
-		1000.0,
-		2000.0,
+		900.0,
+		1900.0,
 		aggregators.Avg,
 		200.0,
 		aggregators.Max,
 		aggregators.NaN,
 		nil)
 	aggregator.Add(tsdb.TimeSeries{
-		{1000.0, 42.0}, {1030.0, 54.0}, {1199.999, 49.5},
-		{1401.0, 20.0}, {1599.0, 30.5},
-		{1836.0, 98.0}})
+		{900.0, 42.0}, {930.0, 54.0}, {1099.999, 49.5},
+		{1301.0, 20.0}, {1499.0, 30.5},
+		{1736.0, 98.0}})
 	aggregator.Add(tsdb.TimeSeries{
-		{1500.0, 1025.0},
-		{1600.0, 99.0},
-		{1800.0, 198.0}, {1801.0, 202.0}, {1999.1, 200.0}})
+		{1400.0, 1025.0},
+		{1500.0, 99.0},
+		{1700.0, 198.0}, {1701.0, 202.0}, {1899.1, 200.0}})
 	aggregator.Add(tsdb.TimeSeries{
-		{1400.0, 1975.0},
-		{1450.0, 2000.0},
-		{1599.0, 2025.0},
-		{1599.1, 2050.0},
-		{1599.2, 2075.0}})
+		{1300.0, 1975.0},
+		{1350.0, 2000.0},
+		{1499.0, 2025.0},
+		{1499.1, 2050.0},
+		{1499.2, 2075.0}})
 	aggregator.Add(nil)
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
@@ -311,27 +311,27 @@ func TestAverageMax(t *testing.T) {
 
 func TestMaxAverage(t *testing.T) {
 	aggregator := aggregators.New(
-		1000.0,
-		2000.0,
+		900.0,
+		1900.0,
 		aggregators.Max,
 		200.0,
 		aggregators.Avg,
 		aggregators.NaN,
 		nil)
 	aggregator.Add(tsdb.TimeSeries{
-		{1000.0, 42.0}, {1030.0, 54.0}, {1199.999, 49.5},
-		{1401.0, 20.0}, {1599.0, 30.0},
-		{1836.0, 98.0}})
+		{900.0, 42.0}, {930.0, 54.0}, {1099.999, 49.5},
+		{1301.0, 20.0}, {1499.0, 30.0},
+		{1736.0, 98.0}})
 	aggregator.Add(tsdb.TimeSeries{
-		{1500.0, 1025.0},
-		{1600.0, 99.0},
-		{1800.0, 198.0}, {1801.0, 202.0}, {1999.1, 200.0}})
+		{1400.0, 1025.0},
+		{1500.0, 99.0},
+		{1700.0, 198.0}, {1701.0, 202.0}, {1899.1, 200.0}})
 	aggregator.Add(tsdb.TimeSeries{
-		{1400.0, 1975.0},
-		{1450.0, 2000.0},
-		{1599.0, 2025.0},
-		{1599.1, 2050.0},
-		{1599.2, 2075.0}})
+		{1300.0, 1975.0},
+		{1350.0, 2000.0},
+		{1499.0, 2025.0},
+		{1499.1, 2050.0},
+		{1499.2, 2075.0}})
 	aggregator.Add(nil)
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
@@ -344,27 +344,27 @@ func TestMaxAverage(t *testing.T) {
 
 func TestSumAverage(t *testing.T) {
 	aggregator := aggregators.New(
-		1000.0,
-		2000.0,
+		900.0,
+		1900.0,
 		aggregators.Sum,
 		200.0,
 		aggregators.Avg,
 		aggregators.NaN,
 		nil)
 	aggregator.Add(tsdb.TimeSeries{
-		{1000.0, 42.0}, {1030.0, 54.0}, {1199.999, 49.5},
-		{1401.0, 20.0}, {1599.0, 30.0},
-		{1836.0, 98.0}})
+		{900.0, 42.0}, {930.0, 54.0}, {1099.999, 49.5},
+		{1301.0, 20.0}, {1499.0, 30.0},
+		{1736.0, 98.0}})
 	aggregator.Add(tsdb.TimeSeries{
-		{1500.0, 1025.0},
-		{1600.0, 99.0},
-		{1800.0, 198.0}, {1801.0, 202.0}, {1999.1, 200.0}})
+		{1400.0, 1025.0},
+		{1500.0, 99.0},
+		{1700.0, 198.0}, {1701.0, 202.0}, {1899.1, 200.0}})
 	aggregator.Add(tsdb.TimeSeries{
-		{1400.0, 1975.0},
-		{1450.0, 2000.0},
-		{1599.0, 2025.0},
-		{1599.1, 2050.0},
-		{1599.2, 2075.0}})
+		{1300.0, 1975.0},
+		{1350.0, 2000.0},
+		{1499.0, 2025.0},
+		{1499.1, 2050.0},
+		{1499.2, 2075.0}})
 	aggregator.Add(nil)
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
@@ -377,17 +377,17 @@ func TestSumAverage(t *testing.T) {
 
 func TestAverageStrangeStartAndEnd(t *testing.T) {
 	aggregator := aggregators.New(
-		1057.0,
-		1938.0,
+		957.0,
+		1838.0,
 		aggregators.Avg,
 		200.0,
 		aggregators.Avg,
 		aggregators.NaN,
 		nil)
 	aggregator.Add(tsdb.TimeSeries{
-		{1057.0, 30.0}, {1199.0, 40.0},
-		{1401.0, 20.0}, {1599.0, 30.0},
-		{1836.0, 98.0}})
+		{957.0, 30.0}, {1099.0, 40.0},
+		{1301.0, 20.0}, {1499.0, 30.0},
+		{1736.0, 98.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{{1400.0, 25.0}}
 	assertValueDeepEqual(t, expected, aggregated)
@@ -414,17 +414,17 @@ func TestStartEqualsEnd(t *testing.T) {
 
 func TestNegativeStart(t *testing.T) {
 	aggregator := aggregators.New(
-		-29028.0,
-		29028.0,
+		-34028.0,
+		24028.0,
 		aggregators.Avg,
 		10000.0,
 		aggregators.Avg,
 		aggregators.NaN,
 		nil)
 	aggregator.Add(tsdb.TimeSeries{
-		{-29028.0, -60.0}, {-21000.0, -50.0},
-		{-3000.0, -5.0}, {3000.0, 5.0},
-		{29027.0, 43.0}})
+		{-34028.0, -60.0}, {-26000.0, -50.0},
+		{-8000.0, -5.0}, {-2000.0, 5.0},
+		{24027.0, 43.0}})
 	aggregated := aggregator.Aggregate()
 	expected := tsdb.TimeSeries{
 		{-10000.0, -5.0},

--- a/tsdb/aggregators/specific_aggregator_test.go
+++ b/tsdb/aggregators/specific_aggregator_test.go
@@ -58,7 +58,7 @@ func (a *aggregatorTesterType) expect(
 func (a *aggregatorTesterType) Verify(t *testing.T) {
 	length := len(a.expected)
 	agg := aggregators.New(
-		0, float64(length)*kMaxSampleSize,
+		kMaxSampleSize*-0.5, (float64(length)-0.5)*kMaxSampleSize,
 		aggregators.Sum,
 		kMaxSampleSize,
 		a.aggregator,
@@ -70,7 +70,7 @@ func (a *aggregatorTesterType) Verify(t *testing.T) {
 			timeSeries = append(
 				timeSeries,
 				tsdb.TsValue{
-					float64(i)*kMaxSampleSize + float64(j),
+					(float64(i)-0.5)*kMaxSampleSize + float64(j),
 					val})
 		}
 	}

--- a/tsdbimpl/tsdbimpl_test.go
+++ b/tsdbimpl/tsdbimpl_test.go
@@ -67,27 +67,27 @@ func TestAPI(t *testing.T) {
 	endpointId, aStore := appStatus.EndpointIdByHostAndName(
 		"host1", "AnApp")
 	addValues(t, aStore, endpointId, "/foo",
-		500.0, 30.0, 510.0, 31.0, 520.0, 32.0, 530.0, 33.0, 540.0, 34.0)
+		490.0, 30.0, 500.0, 31.0, 510.0, 32.0, 520.0, 33.0, 530.0, 34.0)
 	endpointId, aStore = appStatus.EndpointIdByHostAndName(
 		"host1", "AnotherApp")
 	addValues(t, aStore, endpointId, "/foo",
-		500.0, 40.0, 510.0, 41.0, 520.0, 42.0, 530.0, 43.0, 540.0, 44.0)
+		490.0, 40.0, 500.0, 41.0, 510.0, 42.0, 520.0, 43.0, 530.0, 44.0)
 	endpointId, aStore = appStatus.EndpointIdByHostAndName(
 		"host2", "AnApp")
 	addValues(t, aStore, endpointId, "/foo",
-		500.0, 50.0, 510.0, 51.0, 520.0, 52.0, 530.0, 53.0, 540.0, 54.0)
+		490.0, 50.0, 500.0, 51.0, 510.0, 52.0, 520.0, 53.0, 530.0, 54.0)
 	endpointId, aStore = appStatus.EndpointIdByHostAndName(
 		"host2", "AnotherApp")
 	addValues(t, aStore, endpointId, "/foo",
-		500.0, 60.0, 510.0, 61.0, 520.0, 62.0, 530.0, 63.0, 540.0, 64.0)
+		490.0, 60.0, 500.0, 61.0, 510.0, 62.0, 520.0, 63.0, 530.0, 64.0)
 	endpointId, aStore = appStatus.EndpointIdByHostAndName(
 		"host3", "AnApp")
 	addValues(t, aStore, endpointId, "/foo",
-		500.0, 70.0, 510.0, 71.0, 520.0, 72.0, 530.0, 73.0, 540.0, 74.0)
+		490.0, 70.0, 500.0, 71.0, 510.0, 72.0, 520.0, 73.0, 530.0, 74.0)
 	endpointId, aStore = appStatus.EndpointIdByHostAndName(
 		"host3", "AnotherApp")
 	addValues(t, aStore, endpointId, "/foo",
-		500.0, 80.0, 510.0, 81.0, 520.0, 82.0, 530.0, 83.0, 540.0, 84.0)
+		490.0, 80.0, 500.0, 81.0, 510.0, 82.0, 520.0, 83.0, 530.0, 84.0)
 	endpointId, aStore = appStatus.EndpointIdByHostAndName(
 		"host5", "AnApp")
 	addValues(t, aStore, endpointId, "/bar",
@@ -107,7 +107,7 @@ func TestAPI(t *testing.T) {
 				aggregators.NaN,
 				nil), nil
 		},
-		500.0, 600.0,
+		490.0, 590.0,
 		nil); err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestAPI(t *testing.T) {
 				aggregators.NaN,
 				nil), nil
 		},
-		500.0, 600.0,
+		490.0, 590.0,
 		nil); err != tsdbimpl.ErrNoSuchMetric {
 		t.Error("Expected ErrNoSuchName")
 	}
@@ -158,7 +158,7 @@ func TestAPI(t *testing.T) {
 				aggregators.NaN,
 				nil), nil
 		},
-		500.0, 1000.0,
+		490.0, 990.0,
 		nil); err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func TestAPI(t *testing.T) {
 				aggregators.NaN,
 				nil), nil
 		},
-		501.0, 539.0,
+		491.0, 529.0,
 		nil); err != nil {
 		t.Fatal(err)
 	}
@@ -220,7 +220,7 @@ func TestAPI(t *testing.T) {
 				aggregators.NaN,
 				nil), nil
 		},
-		400.0, 700.0,
+		390.0, 690.0,
 		options); err != nil {
 		t.Fatal(err)
 	}
@@ -276,7 +276,7 @@ func TestAPI(t *testing.T) {
 				aggregators.NaN,
 				nil), nil
 		},
-		700.0, 900.0,
+		690.0, 890.0,
 		options); err != nil {
 		t.Fatal(err)
 	}
@@ -306,7 +306,7 @@ func TestAPI(t *testing.T) {
 				aggregators.NaN,
 				nil), nil
 		},
-		400.0, 700.0,
+		390.0, 690.0,
 		options); err != nil {
 		t.Fatal(err)
 	}
@@ -355,7 +355,7 @@ func TestAPI(t *testing.T) {
 				aggregators.NaN,
 				nil), nil
 		},
-		400.0, 700.0,
+		390.0, 690.0,
 		options); err != nil {
 		t.Fatal(err)
 	}
@@ -443,7 +443,7 @@ func TestAPI(t *testing.T) {
 				aggregators.NaN,
 				nil), nil
 		},
-		700.0, 900.0,
+		690.0, 890.0,
 		options); err != nil {
 		t.Fatal(err)
 	}
@@ -481,7 +481,7 @@ func TestAPI(t *testing.T) {
 				aggregators.NaN,
 				nil), nil
 		},
-		400.0, 700.0,
+		390.0, 690.0,
 		options); err != nil {
 		t.Fatal(err)
 	}
@@ -537,7 +537,7 @@ func TestAPI(t *testing.T) {
 				aggregators.NaN,
 				nil), nil
 		},
-		400.0, 700.0,
+		390.0, 690.0,
 		options); err != nil {
 		t.Fatal(err)
 	}
@@ -578,7 +578,7 @@ func TestAPI(t *testing.T) {
 				aggregators.NaN,
 				nil), nil
 		},
-		400.0, 700.0,
+		390.0, 690.0,
 		options); err != tsdbimpl.ErrNoSuchMetric {
 		t.Error("Expected ErrNoSuchMetric")
 	}


### PR DESCRIPTION
Use last half of previous interval; first half of current interval.