### PR TITLE
Let scotty do the best it can to satisfy queries instead of erroring.

### DIFF
--- a/tsdbexec/tsdbexec.go
+++ b/tsdbexec/tsdbexec.go
@@ -102,6 +102,7 @@ func runParsedQueries(
 	[]*tsdb.TaggedTimeSeriesSet, error) {
 	results := make([]*tsdb.TaggedTimeSeriesSet, len(requests))
 	for i, request := range requests {
+		request.EnsureStartTimeRecentEnough()
 		result, err := runSingleParsedQuery(
 			request, endpoints, minDownSampleTime)
 		if err == tsdbimpl.ErrNoSuchMetric {

--- a/tsdbjson/api.go
+++ b/tsdbjson/api.go
@@ -154,6 +154,12 @@ type ParsedQuery struct {
 	Options ParsedQueryOptions
 }
 
+// EnsureStartTimeRecentEnough moves start time closer to end time if the
+// rollup span is too small for the time range. Otherwise, it is a no-op.
+func (p *ParsedQuery) EnsureStartTimeRecentEnough() {
+	p.ensureStartTimeRecentEnough()
+}
+
 // ParseQueryRequest takes a JSON /api/query request as input and returns
 // zero or more parsed queries.
 func ParseQueryRequest(

--- a/tsdbjson/tsdbjson.go
+++ b/tsdbjson/tsdbjson.go
@@ -218,6 +218,15 @@ func parseDownSample(downSampleStr string) (result *DownSampleSpec, err error) {
 	return &spec, nil
 }
 
+func (p *ParsedQuery) ensureStartTimeRecentEnough() {
+	if p.Aggregator.DownSample != nil {
+		downSample := p.Aggregator.DownSample
+		if p.End-p.Start/downSample.DurationInSeconds > kMaxDownSampleBuckets {
+			p.Start = p.End - downSample.DurationInSeconds*kMaxDownSampleBuckets
+		}
+	}
+}
+
 func parseQueryRequest(request *QueryRequest) (
 	result []ParsedQuery, err error) {
 	parsedQueries := make([]ParsedQuery, len(request.Queries))


### PR DESCRIPTION
If the time range for a query is so long that the number of rollup
buckets needed exceeds, scotty's limit of 1000, let scotty move the
start time forward to that the number of buckets is 1000 rather than
returning an error. This way, scotty satisfies the query, but may not
return older data. This is fine as proxima doesn't expect scotty to
return all the data every time.