### PR TITLE
DO NOT MERGE -- Add queuesender.

### DIFF
--- a/lib/queuesender/api.go
+++ b/lib/queuesender/api.go
@@ -1,0 +1,43 @@
+package queuesender
+
+import (
+	"log"
+	"sync"
+)
+
+// Sender sends JSON requests asynchronously
+type Sender struct {
+	// log messages logged here
+	logger *loggerType
+	// requests queued here
+	queue *queueType
+	// channel to request that the connection be refreshed.
+	// Send id of connection. Each connection refreshed once even if id
+	// sent multiple times.
+	connResetCh chan int
+	// lock for connection and connection id
+	lock sync.Mutex
+	// condition variable for the same
+	cond sync.Cond
+	// connection id. Starts at 0. Increments by 1 each time
+	// connection is refreshed.
+	connId int
+	// connection. Changes with each connection refresh.
+	conn *connType
+}
+
+// New returns a new sender.
+// endpoint is the common base of all endpoints
+// size is the size of the queue
+// name is the name of queue. Used strictly for logging
+// logger is the logger to receive the logs.
+func New(endpoint string, size int, name string, logger *log.Logger) (
+	*Sender, error) {
+	return _new(endpoint, size, name, logger)
+}
+
+// Send sends given json to the given endpoint.
+// Send will block if queue if full because of encountered errors.
+func (s *Sender) Send(endpoint string, json interface{}) {
+	s.queue.Add(requestType{Endpoint: endpoint, Json: json})
+}

--- a/lib/queuesender/conn.go
+++ b/lib/queuesender/conn.go
@@ -1,0 +1,123 @@
+package queuesender
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+var (
+	kErrNoConnection = errors.New("queuesender: No connection")
+)
+
+// connType represents a single connection.
+type connType struct {
+	conn    net.Conn
+	br      *bufio.Reader
+	refresh func() (net.Conn, error)
+}
+
+func extractEndpoint(urlStr string) (scheme, endpoint string, err error) {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return "", "", err
+	}
+	host := u.Host
+	if u.Scheme == "https" && !strings.Contains(u.Host, ":") {
+		host = host + ":443"
+	}
+	if u.Scheme == "http" && !strings.Contains(u.Host, ":") {
+		host = host + ":80"
+	}
+	return u.Scheme, host, nil
+}
+
+func newConn(urlStr string) (*connType, error) {
+	scheme, endpoint, err := extractEndpoint(urlStr)
+	if err != nil {
+		return nil, err
+	}
+	var refresh func() (net.Conn, error)
+	if scheme == "https" {
+		refresh = func() (net.Conn, error) {
+			return tls.Dial("tcp", endpoint, nil)
+		}
+	}
+	if refresh == nil {
+		return nil, errors.New("Unsupported scheme")
+	}
+	conn, err := refresh()
+	if err != nil {
+		return nil, err
+	}
+	return _newConn(conn, refresh), nil
+}
+
+func _newConn(conn net.Conn, refresh func() (net.Conn, error)) *connType {
+	if conn == nil {
+		return &connType{refresh: refresh}
+	}
+	return &connType{
+		conn: conn, br: bufio.NewReader(conn), refresh: refresh}
+
+}
+
+func (c *connType) RefreshAndClose(logger *loggerType) *connType {
+	if c.conn != nil {
+		c.conn.Close()
+	}
+	newConn, err := c.refresh()
+	if err != nil {
+		logger.Log(err)
+	}
+	return _newConn(newConn, c.refresh)
+}
+
+func (c *connType) Send(req requestType) error {
+	if c.conn == nil {
+		return kErrNoConnection
+	}
+	buffer, err := encodeJSON(req.Json)
+	if err != nil {
+		return err
+	}
+	httpreq, err := http.NewRequest("POST", req.Endpoint, buffer)
+	if err != nil {
+		return err
+	}
+	httpreq.Header.Set("Content-Type", "application/json")
+	return httpreq.Write(c.conn)
+}
+
+func (c *connType) Read() (bool, error) {
+	if c.br == nil {
+		return false, kErrNoConnection
+	}
+	resp, err := http.ReadResponse(c.br, nil)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		var buffer bytes.Buffer
+		io.Copy(&buffer, resp.Body)
+		return true, errors.New(resp.Status + ": " + buffer.String())
+	}
+	return true, nil
+}
+
+func encodeJSON(payload interface{}) (*bytes.Buffer, error) {
+	result := &bytes.Buffer{}
+	encoder := json.NewEncoder(result)
+	if err := encoder.Encode(payload); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/lib/queuesender/logger.go
+++ b/lib/queuesender/logger.go
@@ -1,0 +1,20 @@
+package queuesender
+
+import (
+	"log"
+)
+
+// loggerType logs errors.
+type loggerType struct {
+	logger *log.Logger
+	// the prefix for each log
+	name string
+}
+
+// Log logs the error. Calling log on a nil receiver does nothing.
+func (l *loggerType) Log(err error) {
+	if l == nil {
+		return
+	}
+	l.logger.Printf("%s:%v", l.name, err)
+}

--- a/lib/queuesender/queue.go
+++ b/lib/queuesender/queue.go
@@ -1,0 +1,153 @@
+package queuesender
+
+import (
+	"sync"
+)
+
+// queueType is a circular queue of fixed length for sending JSON requests
+// asynchronously. These queues have 3 pointers:
+//
+// the front of the queue where the next sent request to receive a response
+// resides.
+//
+// the back of the queue where new requests to be sent go.
+//
+// the next not sent pointer which falls somewhere between the front and back
+// of the queue.
+//
+// Requests get added to the back of the queue. At some point the next not
+// sent pointer reaches the added request, and the request is sent. Later
+// the response for that request comes, and the request is popped off the
+// front of the queue.
+type queueType struct {
+	lock        sync.Mutex
+	cond        sync.Cond
+	data        []requestType
+	length      int
+	start       int
+	end         int
+	nextNotSent int
+	connId      int
+}
+
+// newQueue returns a new queue capable of holding length requests.
+func newQueue(length int) *queueType {
+	result := &queueType{length: length + 1}
+	result.cond.L = &result.lock
+	result.data = make([]requestType, length+1)
+	return result
+}
+
+// Add adds r to the back of the queue. Add blocks if queue is full
+func (q *queueType) Add(r requestType) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	for q.isFull() {
+		q.cond.Wait()
+	}
+	q.data[q.end] = r
+	q.incEnd()
+	q.cond.Broadcast()
+}
+
+// DiscardNextSent pops the next item off the front of the queue.
+// Called when a response comes in
+// DiscardNextSent blocks if the queue is empty
+func (q *queueType) DiscardNextSent() {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	if q.isEmpty() {
+		q.cond.Wait()
+	}
+	q.incStart()
+	q.cond.Broadcast()
+}
+
+// MoveToNotSent is for when an error comes back in the response.
+// MoveToNotSent moves the item at the front of the queue to the back of
+// the queue atomially. MoveToNotSent blocks if queue is empty.
+func (q *queueType) MoveToNotSent() {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	if q.isEmpty() {
+		q.cond.Wait()
+	}
+	q.data[q.end] = q.data[q.start]
+	q.incEnd()
+	q.incStart()
+	q.cond.Broadcast()
+}
+
+// NextNotSent returns the next item in the queue not yet sent and moves
+// the next not sent pointer forward. NextNotSent blocks if nothing remains
+// in the queue that hasn't been sent.
+//
+// NextNotSent depends on the current connection. Whenever the connection is
+// refreshed, NextNotSent moves to the front of the queue. The connId
+// argument helps protect against data races. The passed connId must match
+// the ID of the connection this queue is tracking. A connId that is too big
+// means the caller is asking for the next not sent pointer for a future
+// connection. In this case, NextNotSent blocks until the connection Ids match.
+// A connId that is to small means that the caller is asking for the next not
+// sent pointer of a connection that has been closed. In this case,
+// NextNotSent immediately returns false.
+func (q *queueType) NextNotSent(connId int) (result requestType, ok bool) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	for connId > q.connId {
+		q.cond.Wait()
+	}
+	for connId == q.connId && q.noNotSent() {
+		q.cond.Wait()
+	}
+	if connId < q.connId {
+		return
+	}
+	result = q.data[q.nextNotSent]
+	ok = true
+	q.incNextNotSent()
+	q.cond.Broadcast()
+	return
+}
+
+// Calling ResetNextNotSent indicates the most current connection has changed.
+// ResetNextNotSent moves the next not sent pointer to the front of the
+// queue and updates the connection id being tracked while unblocking any
+// pending calls for the older connection.
+func (q *queueType) ResetNextNotSent(newConnId int) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	if newConnId <= q.connId {
+		panic("Connection Ids must be monotone increasing")
+	}
+	q.nextNotSent = q.start
+	q.connId = newConnId
+	q.cond.Broadcast()
+}
+
+func (q *queueType) incEnd() {
+	q.end = (q.end + 1) % q.length
+}
+
+func (q *queueType) incStart() {
+	if q.start == q.nextNotSent {
+		q.incNextNotSent()
+	}
+	q.start = (q.start + 1) % q.length
+}
+
+func (q *queueType) incNextNotSent() {
+	q.nextNotSent = (q.nextNotSent + 1) % q.length
+}
+
+func (q *queueType) isEmpty() bool {
+	return q.start == q.end
+}
+
+func (q *queueType) isFull() bool {
+	return (q.end+1)%q.length == q.start
+}
+
+func (q *queueType) noNotSent() bool {
+	return q.nextNotSent == q.end
+}

--- a/lib/queuesender/request.go
+++ b/lib/queuesender/request.go
@@ -1,0 +1,9 @@
+package queuesender
+
+// requestType represents a request
+type requestType struct {
+	// the endpoint
+	Endpoint string
+	// the json
+	Json interface{}
+}

--- a/lib/queuesender/sender.go
+++ b/lib/queuesender/sender.go
@@ -1,0 +1,112 @@
+package queuesender
+
+import (
+	"log"
+)
+
+func _new(endpoint string, size int, name string, logger *log.Logger) (
+	*Sender, error) {
+	if size < 1 {
+		panic("Size must be at least 1")
+	}
+	conn, err := newConn(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	result := &Sender{
+		queue:       newQueue(size),
+		connResetCh: make(chan int, 10),
+	}
+	if logger != nil {
+		result.logger = &loggerType{name: name, logger: logger}
+	}
+	result.cond.L = &result.lock
+	result.conn = conn
+	go result.connResetLoop()
+	go result.sendLoop()
+	go result.receiveLoop()
+	return result, nil
+}
+
+// getConn fetches the current connection Id and connection which can
+// change at any time.
+func (s *Sender) getConn() (int, *connType) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.connId, s.conn
+}
+
+// setConn Sets the current connection ID and connection
+func (s *Sender) setConn(connId int, conn *connType) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.connId, s.conn = connId, conn
+	s.cond.Broadcast()
+}
+
+// waitForRefresh blocks the caller until the current connection has an id
+// bigger than connId.
+func (s *Sender) waitForRefresh(connId int) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	for s.connId <= connId {
+		s.cond.Wait()
+	}
+}
+
+// This loop handles requests to refresh the connection
+func (s *Sender) connResetLoop() {
+	for connIdToReset := range s.connResetCh {
+		connId, conn := s.getConn()
+		// Only do the refresh if the conn ids match. This check ensures that
+		// each connection gets refreshed only once.
+		if connId == connIdToReset {
+			newConn := conn.RefreshAndClose(s.logger)
+			s.setConn(connId+1, newConn)
+			s.queue.ResetNextNotSent(connId + 1)
+		}
+	}
+}
+
+// This loop sends requests in the queue.
+func (s *Sender) sendLoop() {
+	for {
+		connId, conn := s.getConn()
+		req, ok := s.queue.NextNotSent(connId)
+		if !ok {
+			// A new connection is available
+			continue
+		}
+		err := conn.Send(req)
+		// On error we have to refresh the connection
+		if err != nil {
+			s.connResetCh <- connId
+			// Avoids using the same bad connection over and over again
+			s.waitForRefresh(connId)
+		}
+	}
+}
+
+// This loop receives the responses from the requests.
+// Responses received are expected to come in the same order as requests are
+// sent.
+func (s *Sender) receiveLoop() {
+	for {
+		connId, conn := s.getConn()
+		ok, err := conn.Read()
+		// Oops we have to refresh the connection
+		if !ok {
+			s.connResetCh <- connId
+			// Avoids using the same bad connection over and over
+			s.waitForRefresh(connId)
+			continue
+		}
+		// A real error in response
+		if err != nil {
+			s.logger.Log(err)
+			s.queue.MoveToNotSent()
+		} else {
+			s.queue.DiscardNextSent()
+		}
+	}
+}


### PR DESCRIPTION
I implemented the queue that we talked about yesterday.

With this scheme I still only get ~370 requests sent per second or about
22K per minute. I am not using scotty, just a simple stand along program
that calls Send in a loop.

Implementing the queue was rather complicated because of connection
refreshes. Either the sending goroutine or the receiving goroutine can
initiate a connection refresh, but both goroutines have to handle a
connection refresh happening at any time.  Moreover, if a connection goes bad,
both the sending and receiving gorotines may try to refresh the
connection at exactly the same time. In addition, whenever a connection refresh
happens, both the sending and receiving goroutines must receive the new
connection. Finally, the the "next request to be sent" pointer in the
queue must be reset to the front of the queue with each connection refresh.

To facilitate handling connection refreshes, I associate a monotonic
increasing connection ID with each connection. This connection ID  makes
it possible to ensure that each connection gets refreshed only one time
even if both the sending and receiving goroutines initiate a connection
refresh at the same time.

I believe that this implementation is slow because when a connection
does fail, I have to resend everything in the queue with the new
connection I create that didn't get a response with the old connection.

By doing this exercise, I learned that LMM can send unsolicited
responses that don't pair with any request which breaks our assumption
that we can accurately pair responses with requests. LMM will send a
status code 408 if we haven't sent any requests in awhile. Although we
can code for 408, there could be other responses that could come that i
don't know about yet.

Despite my efforts, this implementation won't be as fast as we would
like it to be.

Please feel free to give feedback on the code. There may be a simpler
way to do this than what I found.