### PR TITLE
The sending queue.

### DIFF
--- a/lib/queuesender/api.go
+++ b/lib/queuesender/api.go
@@ -1,0 +1,42 @@
+package queuesender
+
+import (
+	"log"
+	"sync"
+)
+
+// Sender sends JSON requests asynchronously
+type Sender struct {
+	// log messages logged here
+	logger *loggerType
+	// requests queued here
+	queue              *queueType
+	newConnCh          chan *connType
+	newConnReqCh       chan bool
+	lock               sync.Mutex
+	lastResponseError  string
+	responseErrorCount uint64
+	successfulWrites   uint64
+}
+
+// New returns a new sender.
+// endpoint is the common base of all endpoints.
+// size is the size of the queue.
+// name is the name of queue. Used strictly for logging.
+// logger is the logger to receive the logs.
+func New(endpoint string, size int, name string, logger *log.Logger) (
+	*Sender, error) {
+	return _new(endpoint, size, name, logger)
+}
+
+// Send sends given json to the given endpoint.
+// Send will block if queue if full because of encountered errors.
+func (s *Sender) Send(endpoint string, json interface{}) {
+	s.queue.Add(requestType{Endpoint: endpoint, Json: json})
+}
+
+// Register registers metrics for this instance with tricorder.
+// Metrics registered under "/asyncWriters/<name>"
+func (s *Sender) Register(name string) error {
+	return s.register(name)
+}

--- a/lib/queuesender/conn.go
+++ b/lib/queuesender/conn.go
@@ -1,0 +1,144 @@
+package queuesender
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+var (
+	kErrNoConnection = errors.New("queuesender: No connection")
+)
+
+// connType represents a single connection.
+type connType struct {
+	refresh func() (net.Conn, error)
+	lock    sync.Mutex
+	conn    net.Conn
+	br      *bufio.Reader
+}
+
+func extractEndpoint(urlStr string) (scheme, endpoint string, err error) {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return "", "", err
+	}
+	host := u.Host
+	if u.Scheme == "https" && !strings.Contains(u.Host, ":") {
+		host = host + ":443"
+	}
+	if u.Scheme == "http" && !strings.Contains(u.Host, ":") {
+		host = host + ":80"
+	}
+	return u.Scheme, host, nil
+}
+
+func newConn(urlStr string) (*connType, error) {
+	scheme, endpoint, err := extractEndpoint(urlStr)
+	if err != nil {
+		return nil, err
+	}
+	var refresh func() (net.Conn, error)
+	if scheme == "https" {
+		refresh = func() (net.Conn, error) {
+			return tls.Dial("tcp", endpoint, nil)
+		}
+	}
+	if refresh == nil {
+		return nil, errors.New("Unsupported scheme")
+	}
+	conn, err := refresh()
+	if err != nil {
+		return nil, err
+	}
+	return _newConn(conn, refresh), nil
+}
+
+func _newConn(conn net.Conn, refresh func() (net.Conn, error)) *connType {
+	if conn == nil {
+		return &connType{refresh: refresh}
+	}
+	return &connType{
+		conn: conn, br: bufio.NewReader(conn), refresh: refresh}
+
+}
+
+func (c *connType) Close() {
+	c.conn.Close()
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.conn != nil {
+		c.conn = nil
+		c.br = nil
+	}
+}
+
+func (c *connType) _get() (net.Conn, *bufio.Reader) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.conn, c.br
+}
+
+func (c *connType) Refresh(logger *loggerType) *connType {
+	newConn, err := c.refresh()
+	if err != nil {
+		logger.Log(err)
+	}
+	return _newConn(newConn, c.refresh)
+}
+
+func (c *connType) Send(req requestType) error {
+	conn, _ := c._get()
+	if conn == nil {
+		return kErrNoConnection
+	}
+	buffer, err := encodeJSON(req.Json)
+	if err != nil {
+		return err
+	}
+	httpreq, err := http.NewRequest("POST", req.Endpoint, buffer)
+	if err != nil {
+		return err
+	}
+	httpreq.Header.Set("Content-Type", "application/json")
+	return httpreq.Write(conn)
+}
+
+func (c *connType) Read() (bool, error) {
+	_, br := c._get()
+	if br == nil {
+		return false, kErrNoConnection
+	}
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		var buffer bytes.Buffer
+		io.Copy(&buffer, resp.Body)
+		// 408 is a special error meaning that the connection timed out
+		// because we didn't send any request. 408 errors don't go with
+		// any particular request. When we get one of these, assume the
+		// connection is bad.
+		return resp.StatusCode != 408, errors.New(resp.Status + ": " + buffer.String())
+	}
+	return true, nil
+}
+
+func encodeJSON(payload interface{}) (*bytes.Buffer, error) {
+	result := &bytes.Buffer{}
+	encoder := json.NewEncoder(result)
+	if err := encoder.Encode(payload); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/lib/queuesender/logger.go
+++ b/lib/queuesender/logger.go
@@ -1,0 +1,20 @@
+package queuesender
+
+import (
+	"log"
+)
+
+// loggerType logs errors.
+type loggerType struct {
+	logger *log.Logger
+	// the prefix for each log
+	name string
+}
+
+// Log logs the error. Calling log on a nil receiver does nothing.
+func (l *loggerType) Log(err error) {
+	if l == nil {
+		return
+	}
+	l.logger.Printf("%s:%v", l.name, err)
+}

--- a/lib/queuesender/queue.go
+++ b/lib/queuesender/queue.go
@@ -1,0 +1,178 @@
+package queuesender
+
+import (
+	"sync"
+)
+
+// queueType is a circular queue of fixed length for sending JSON requests
+// asynchronously. These queues have 3 pointers:
+//
+// the front of the queue where the next sent request to receive a response
+// resides.
+//
+// the back of the queue where new requests to be sent go.
+//
+// the next not sent pointer which falls somewhere between the front and back
+// of the queue.
+//
+// Requests get added to the back of the queue. At some point the next not
+// sent pointer reaches the added request, and the request is sent. Later
+// the response for that request comes, and the request is popped off the
+// front of the queue.
+type queueType struct {
+	length      int
+	lock        sync.Mutex
+	cond        sync.Cond
+	data        []requestType
+	start       int
+	end         int
+	nextNotSent int
+	connId      int
+}
+
+// newQueue returns a new queue capable of holding length requests.
+func newQueue(length int) *queueType {
+	result := &queueType{length: length + 1}
+	result.cond.L = &result.lock
+	result.data = make([]requestType, length+1)
+	return result
+}
+
+func (q *queueType) Cap() int {
+	return q.length - 1
+}
+
+func (q *queueType) Len() int {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	result := q.end - q.start
+	if result < 0 {
+		result += q.length
+	}
+	return result
+}
+
+func (q *queueType) Sent() int {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	result := q.nextNotSent - q.start
+	if result < 0 {
+		result += q.length
+	}
+	return result
+}
+
+// Add adds r to the back of the queue. Add blocks if queue is full
+func (q *queueType) Add(r requestType) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	for q.isFull() {
+		q.cond.Wait()
+	}
+	q.data[q.end] = r
+	q.incEnd()
+	q.cond.Broadcast()
+}
+
+// DiscardNextSent pops the next item off the front of the queue.
+// Called when a response comes in
+// DiscardNextSent blocks if the queue is empty
+func (q *queueType) DiscardNextSent() {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	if q.isEmpty() {
+		q.cond.Wait()
+	}
+	q.incStart()
+	q.cond.Broadcast()
+}
+
+// MoveToNotSent is for when an error comes back in the response.
+// MoveToNotSent moves the item at the front of the queue to the back of
+// the queue atomially. MoveToNotSent blocks if queue is empty.
+func (q *queueType) MoveToNotSent() requestType {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	if q.isEmpty() {
+		q.cond.Wait()
+	}
+	q.data[q.end] = q.data[q.start]
+	q.incEnd()
+	q.incStart()
+	q.cond.Broadcast()
+	return q.data[q.end]
+}
+
+// NextNotSent returns the next item in the queue not yet sent and moves
+// the next not sent pointer forward. NextNotSent blocks if nothing remains
+// in the queue that hasn't been sent.
+//
+// NextNotSent depends on the current connection. Whenever the connection is
+// refreshed, NextNotSent moves to the front of the queue. The connId
+// argument helps protect against data races. The passed connId must match
+// the ID of the connection this queue is tracking. A connId that is too big
+// means the caller is asking for the next not sent pointer for a future
+// connection. In this case, NextNotSent blocks until the connection Ids match.
+// A connId that is to small means that the caller is asking for the next not
+// sent pointer of a connection that has been closed. In this case,
+// NextNotSent immediately returns false.
+func (q *queueType) NextNotSent(connId int) (result requestType, ok bool) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	for connId > q.connId {
+		q.cond.Wait()
+	}
+	for connId == q.connId && q.noNotSent() {
+		q.cond.Wait()
+	}
+	if connId < q.connId {
+		return
+	}
+	result = q.data[q.nextNotSent]
+	ok = true
+	q.incNextNotSent()
+	q.cond.Broadcast()
+	return
+}
+
+// Calling ResetNextNotSent indicates the most current connection has changed.
+// ResetNextNotSent moves the next not sent pointer to the front of the
+// queue and updates the connection id being tracked while unblocking any
+// pending calls for the older connection.
+func (q *queueType) ResetNextNotSent(newConnId int) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	if newConnId <= q.connId {
+		panic("Connection Ids must be monotone increasing")
+	}
+	q.nextNotSent = q.start
+	q.connId = newConnId
+	q.cond.Broadcast()
+}
+
+func (q *queueType) incEnd() {
+	q.end = (q.end + 1) % q.length
+}
+
+func (q *queueType) incStart() {
+	if q.start == q.nextNotSent {
+		q.incNextNotSent()
+	}
+	q.start = (q.start + 1) % q.length
+}
+
+func (q *queueType) incNextNotSent() {
+	q.nextNotSent = (q.nextNotSent + 1) % q.length
+}
+
+func (q *queueType) isEmpty() bool {
+	return q.start == q.end
+}
+
+func (q *queueType) isFull() bool {
+	return (q.end+1)%q.length == q.start
+}
+
+func (q *queueType) noNotSent() bool {
+	return q.nextNotSent == q.end
+}

--- a/lib/queuesender/request.go
+++ b/lib/queuesender/request.go
@@ -1,0 +1,9 @@
+package queuesender
+
+// requestType represents a request
+type requestType struct {
+	// the endpoint
+	Endpoint string
+	// the json
+	Json interface{}
+}

--- a/lib/queuesender/sender.go
+++ b/lib/queuesender/sender.go
@@ -1,0 +1,190 @@
+package queuesender
+
+import (
+	"fmt"
+	"github.com/Symantec/tricorder/go/tricorder"
+	"github.com/Symantec/tricorder/go/tricorder/units"
+	"log"
+)
+
+func _new(endpoint string, size int, name string, logger *log.Logger) (
+	*Sender, error) {
+	if size < 1 {
+		panic("Size must be at least 1")
+	}
+	conn, err := newConn(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	result := &Sender{
+		queue:        newQueue(size),
+		newConnCh:    make(chan *connType),
+		newConnReqCh: make(chan bool),
+	}
+	if logger != nil {
+		result.logger = &loggerType{name: name, logger: logger}
+	}
+	go result.sendLoop(conn)
+	go result.receiveLoop(conn)
+	return result, nil
+}
+
+// This loop sends requests in the queue. To coordinate connection refreshes
+// between the send loop and receive loop goroutines, only this send loop
+// closes stale connections, and only the receiving loop refreshes connections.
+// Whenever this send loop closes a stale connection, the receiving loop has
+// moved on to using a new connection.
+func (s *Sender) sendLoop(conn *connType) {
+	connId := 0
+	for {
+		// See if the receiving loop has a new connection for us.
+		// If not, just keep using the same connection
+		select {
+		case newConn := <-s.newConnCh:
+			// We know its safe to close the old connection because
+			// the receiving loop is already using the connection it
+			// just gave us.
+			conn.Close()
+			conn = newConn
+			// For a given connection, both the send and receiving loop
+			// use the same value for connection ID.
+			connId++
+		default:
+		}
+		req, ok := s.queue.NextNotSent(connId)
+		if !ok {
+			// If we get here, the receiver loop has already created
+			// a new connection, and the queue is already tracking it.
+			// Go to the beginning to get this new connection.
+			continue
+		}
+		err := conn.Send(req)
+		// On error we have to refresh the connection
+		if err != nil {
+			// Tell receiving loop to build a new connection
+			s.newConnReqCh <- true
+			// Block waiting for that new connection since the connection we
+			// have is no good.
+			newConn := <-s.newConnCh
+			conn.Close()
+			conn = newConn
+			connId++
+		}
+	}
+}
+
+// This loop receives the responses from the requests.
+// Responses received are expected to come in the same order as requests are
+// sent.
+func (s *Sender) receiveLoop(conn *connType) {
+	connId := 0
+	for {
+		// First see if sending loop wants a new connection
+		select {
+		case <-s.newConnReqCh:
+			// Create the new connection. Note the old connection is still
+			// opened. The sending loop will close it when it gets this new
+			// connection.
+			conn = conn.Refresh(s.logger)
+			connId++
+			// Tell the queue about the new connection ID
+			s.queue.ResetNextNotSent(connId)
+			// Give sending loop this new connection
+			s.newConnCh <- conn
+		default:
+		}
+		ok, err := conn.Read()
+		// Oops we have to refresh the connection
+		if !ok {
+			conn = conn.Refresh(s.logger)
+			connId++
+			s.queue.ResetNextNotSent(connId)
+			s.newConnCh <- conn
+			continue
+		}
+		s.logError(err)
+		// A real error in response
+		if err != nil {
+			s.logger.Log(err)
+			s.queue.MoveToNotSent()
+		} else {
+			s.queue.DiscardNextSent()
+		}
+	}
+}
+
+func (s *Sender) logError(err error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if err == nil {
+		s.successfulWrites++
+		return
+	}
+	s.lastResponseError = err.Error()
+	s.responseErrorCount++
+}
+
+func (s *Sender) LastError() string {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.lastResponseError
+}
+
+func (s *Sender) ErrorCount() uint64 {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.responseErrorCount
+}
+
+func (s *Sender) SuccessCount() uint64 {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.successfulWrites
+}
+
+func (s *Sender) register(prefix string) error {
+	prefix = "/asyncWriters/" + prefix
+	if err := tricorder.RegisterMetric(
+		fmt.Sprintf("%s/%s", prefix, "queueLength"),
+		s.queue.Len,
+		units.None,
+		"count of items in queue"); err != nil {
+		return err
+	}
+	if err := tricorder.RegisterMetric(
+		fmt.Sprintf("%s/%s", prefix, "queueCapacity"),
+		s.queue.Cap,
+		units.None,
+		"capacity of queue"); err != nil {
+		return err
+	}
+	if err := tricorder.RegisterMetric(
+		fmt.Sprintf("%s/%s", prefix, "needsAck"),
+		s.queue.Sent,
+		units.None,
+		"items in queue needing acknowledgement"); err != nil {
+		return err
+	}
+	if err := tricorder.RegisterMetric(
+		fmt.Sprintf("%s/%s", prefix, "lastError"),
+		s.LastError,
+		units.None,
+		"last error encountered"); err != nil {
+		return err
+	}
+	if err := tricorder.RegisterMetric(
+		fmt.Sprintf("%s/%s", prefix, "errorCount"),
+		s.ErrorCount,
+		units.None,
+		"last error encountered"); err != nil {
+		return err
+	}
+	if err := tricorder.RegisterMetric(
+		fmt.Sprintf("%s/%s", prefix, "successCount"),
+		s.SuccessCount,
+		units.None,
+		"successfulWrites"); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This is a totally rewritten sending queue than what I had before. Even with the mutex, I was still getting panics while blocking on the buffered reader about every 15 to 30 minutes.

I reworked the synchronization so the sending and receiving loop will never have their connections closed out from under them.  Only the sending loop closes connections, and it only does so when it is sure that the receiving loop is done with the connection as well.  

This code is simpler than the previous version. Only two go routines instead of 3. No condition variable.  

conn.go - wrapper around net.Conn. Writes JSON to connection and reads responses
logger.go - wrapper around log.logger. logs errors.
queue.go - The queue itself
request.go - One request
sender.go - The meat of this code. Contains the sending and receiving loops. This is the critical file where all the synchronization is. 