### PR TITLE
Fix broken build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ before_install:
 - export TRAVIS_BUILD_DIR=${SYMANTEC_PROJECT_DIR}
 - cd ${SYMANTEC_PROJECT_DIR}
 install:
+- git clone http://github.com/uber-go/atomic ../../uber-go/atomic
+- git --git-dir=../../uber-go/atomic/.git --work-tree=../../uber-go/atomic checkout 74ca5ec
+- git clone http://github.com/uber-go/zap ../../uber-go/zap
+- git --git-dir=../../uber-go/zap/.git --work-tree=../../uber-go/zap checkout fbae028
 - go get github.com/sparrc/gdm
 - go get -t -d github.com/influxdata/influxdb/...
 - ../../../../bin/gdm restore -f ../../influxdata/influxdb/Godeps


### PR DESCRIPTION
zap changed their imports from github.com/uber-go/zap to go.uber.org/zap, but influxdb still uses github.com/uber-org/zap. Unfortunately, go get -t -d doesn't know how to handle changed import paths, and gdm won't work unless everything is checked out in advance.

My solution is to manually clone uber-go/zap and uber-go/atomic repos and set both of those back to the revision that influxdb wants. Then I run go get -t -d and use gdm as usual.

This fix should be fairly robust as gdm will update the zap revision if it does change. However, if the influx team decides to update their imports for zap to the current go.uber.org/zap, it will break this build, and I will have to remove the manual calls to git clone from the travis file.