### PR TITLE
Introduce pool package.

### DIFF
--- a/lib/pool/api.go
+++ b/lib/pool/api.go
@@ -1,0 +1,54 @@
+// Package pool provides pools for io.Closer instances.
+//
+// The pools automatically close instances no longer in use. Clients should
+// never call Close() directly on a pool managed closer.
+//
+// Code works like this:
+// 	p := pool.New...(...)
+//	...
+// 	func someFunc() {
+// 		id, closer := p.Get()
+// 		defer p.Put(id)
+// 		doSomethingWithCloserWithoutClosingIt(closer)
+// 	}
+package pool
+
+import (
+	"io"
+	"sync"
+)
+
+// SingleResource is a pool of a single closer.
+// Client can change the underlying closer at any time.
+type SingleResource struct {
+	mu        sync.Mutex
+	closers   map[uint64]*singleResourceType
+	currentId uint64
+}
+
+// NewSingleResource creates a new instance containing just closer.
+func NewSingleResource(closer io.Closer) *SingleResource {
+	return &SingleResource{
+		closers: map[uint64]*singleResourceType{
+			0: &singleResourceType{closer: closer},
+		},
+	}
+}
+
+// Set sets the closer in this instance
+func (r *SingleResource) Set(closer io.Closer) {
+	r.set(closer)
+}
+
+// Get returns the id and closer of the current closer in this instance.
+// Client should follow each Get call with a deferred Put() call as in the
+// package example.
+func (r *SingleResource) Get() (uint64, io.Closer) {
+	return r.get()
+}
+
+// Put signals to this instance that caller is done using the associated
+// closer. id is the same id that Get() returned.
+func (r *SingleResource) Put(id uint64) {
+	r.put(id)
+}

--- a/lib/pool/pool.go
+++ b/lib/pool/pool.go
@@ -1,0 +1,57 @@
+package pool
+
+import (
+	"io"
+)
+
+type singleResourceType struct {
+	closer io.Closer
+	count  int
+	done   bool
+}
+
+func (s *singleResourceType) Open() io.Closer {
+	s.count++
+	return s.closer
+}
+
+func (s *singleResourceType) MarkDone() {
+	s.done = true
+	if s.count == 0 {
+		go s.closer.Close()
+	}
+}
+
+func (s *singleResourceType) Close() bool {
+	s.count--
+	if s.count < 0 {
+		panic("Reference count can't be negative")
+	}
+	if s.count == 0 && s.done == true {
+		go s.closer.Close()
+		return true
+	}
+	return false
+}
+
+func (r *SingleResource) set(closer io.Closer) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.closers[r.currentId].MarkDone()
+	r.currentId++
+	r.closers[r.currentId] = &singleResourceType{closer: closer}
+}
+
+func (r *SingleResource) get() (uint64, io.Closer) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.currentId, r.closers[r.currentId].Open()
+}
+
+func (r *SingleResource) put(id uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closers[id].Close() {
+		delete(r.closers, id)
+	}
+}

--- a/lib/pool/pool_test.go
+++ b/lib/pool/pool_test.go
@@ -1,0 +1,103 @@
+package pool_test
+
+import (
+	"github.com/Symantec/scotty/lib/pool"
+	. "github.com/smartystreets/goconvey/convey"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeCloserType struct {
+	mu         sync.Mutex
+	closeCount int
+}
+
+func (f *fakeCloserType) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closeCount++
+	return nil
+}
+
+func (f *fakeCloserType) NumClosed() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closeCount
+}
+
+type fakeCloserResourceType struct {
+	*pool.SingleResource
+}
+
+func newFakeCloserResource(f *fakeCloserType) *fakeCloserResourceType {
+	return &fakeCloserResourceType{
+		SingleResource: pool.NewSingleResource(f),
+	}
+}
+
+func (f *fakeCloserResourceType) Get() (uint64, *fakeCloserType) {
+	id, val := f.SingleResource.Get()
+	return id, val.(*fakeCloserType)
+}
+
+func (f *fakeCloserResourceType) Set(closer *fakeCloserType) {
+	f.SingleResource.Set(closer)
+}
+
+func TestSingleResource(t *testing.T) {
+	Convey("With New Resource and closers", t, func() {
+		first := &fakeCloserType{}
+		second := &fakeCloserType{}
+		third := &fakeCloserType{}
+		resource := newFakeCloserResource(first)
+		Convey("Getting and putting a closer shouldn't close it.", func() {
+			id, fake := resource.Get()
+			resource.Put(id)
+			time.Sleep(time.Millisecond)
+			So(fake.NumClosed(), ShouldEqual, 0)
+			Convey("But changing the closer should close the first one.", func() {
+				resource.Set(second)
+				time.Sleep(time.Millisecond)
+				So(fake.NumClosed(), ShouldEqual, 1)
+			})
+		})
+		Convey("The closer gotten should be the last one set.", func() {
+			id, fake := resource.Get()
+			So(fake, ShouldEqual, first)
+			resource.Put(id)
+			resource.Set(second)
+			id, fake = resource.Get()
+			So(fake, ShouldEqual, second)
+			resource.Put(id)
+			resource.Set(third)
+			id, fake = resource.Get()
+			So(fake, ShouldEqual, third)
+			resource.Put(id)
+		})
+		Convey("Changing the closer alone won't close previous ones", func() {
+			id1, fake1 := resource.Get()
+			resource.Set(second)
+			id2, fake2 := resource.Get()
+			resource.Set(third)
+			id3, fake3 := resource.Get()
+			So(fake1, ShouldEqual, first)
+			So(fake2, ShouldEqual, second)
+			So(fake3, ShouldEqual, third)
+			time.Sleep(time.Millisecond)
+			So(fake1.NumClosed(), ShouldEqual, 0)
+			So(fake2.NumClosed(), ShouldEqual, 0)
+			So(fake3.NumClosed(), ShouldEqual, 0)
+			Convey("Putting closers will close all but current", func() {
+				resource.Put(id1)
+				resource.Put(id2)
+				resource.Put(id3)
+				time.Sleep(time.Millisecond)
+				So(fake1.NumClosed(), ShouldEqual, 1)
+				So(fake2.NumClosed(), ShouldEqual, 1)
+				So(fake3.NumClosed(), ShouldEqual, 0)
+			})
+
+		})
+	})
+}


### PR DESCRIPTION
When rewriting proxima, I allow for the proxima config file to change at run time. When the config file changes, proxima must free resources associated with the old configuration file even though other goroutines may be using those old resources.

This preventing one goroutine from freeing resources while another is using them is the same problem I had to solve when implementing asynchronous http. Wanting to be sure I get this logic right, I am proposing moving it into its own library here.

The package level comments contain sample code showing how the API works. The tests also show how this API works. 

This API is a work in progress. While this API solves the problem of managing resources in the midst of changing config files for an app like proxima, it does not yet solve the bad connection issues with asynchronous http, but it could in the future.