### PR TITLE
DO NOT MERGE. First shot at API to write to cloud health.

### DIFF
--- a/apps/scotty/collect.go
+++ b/apps/scotty/collect.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	collector "github.com/Symantec/scotty"
 	"github.com/Symantec/scotty/chpipeline"
 	"github.com/Symantec/scotty/cis"
@@ -25,6 +26,14 @@ import (
 	"strings"
 	"sync"
 	"time"
+)
+
+var (
+	kTestInstances = map[string]bool{
+		"i-0a03b9dcf34e861e7": true, // 100.122.1.251
+		"i-004255ea9cf5f15d9": true, // 100.122.1.30
+		"i-03f4ecba13573f961": true, // 100.122.1.36
+	}
 )
 
 var (
@@ -453,12 +462,24 @@ func startCloudFireLoop(
 	}
 
 	go func() {
+		loopCount := 0
 		for {
+			loopCount++
 			call := <-cloudHealthChannel
 			writeStartTime := time.Now()
-			if _, err := cloudHealthWriter.Write(call.Instances, call.Fss); err != nil {
-				lastWriteError = err.Error()
-			} else {
+			/*
+				if _, err := cloudHealthWriter.Write(call.Instances, call.Fss); err != nil {
+					lastWriteError = err.Error()
+				} else {
+					successfulWrites++
+				}
+			*/
+			// if kTestInstances[call.Instances[0].InstanceId] {
+			if loopCount%10 == 0 {
+				fmt.Println("Instance: ", call.Instances)
+				if len(call.Fss) > 0 {
+					fmt.Println("Fss: ", call.Fss)
+				}
 				successfulWrites++
 			}
 			totalWrites++

--- a/apps/scotty/collect.go
+++ b/apps/scotty/collect.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Symantec/scotty/cloudhealth"
 	"github.com/Symantec/scotty/datastructs"
 	"github.com/Symantec/scotty/lib/keyedqueue"
+	"github.com/Symantec/scotty/lib/yamlutil"
 	"github.com/Symantec/scotty/messages"
 	"github.com/Symantec/scotty/metrics"
 	"github.com/Symantec/scotty/store"
@@ -219,8 +220,11 @@ type memoryCheckerType interface {
 }
 
 func createCloudHealthWriter(path string) *cloudhealth.Writer {
-	// TODO
-	return nil
+	var config cloudhealth.Config
+	if err := yamlutil.ReadFromFile(path, &config); err != nil {
+		log.Fatal(err)
+	}
+	return cloudhealth.NewWriter(config)
 }
 
 func startCollector(

--- a/chpipeline/api.go
+++ b/chpipeline/api.go
@@ -60,9 +60,14 @@ func GetStats(list metrics.List) InstanceStats {
 	return getStats(list)
 }
 
-type CloudHealthCall struct {
-	Instances []cloudhealth.InstanceData
-	Fss       []cloudhealth.FsData
+type CloudHealthInstanceCall struct {
+	Instance cloudhealth.InstanceData
+	Fss      []cloudhealth.FsData
+}
+
+func (c CloudHealthInstanceCall) Split() (
+	CloudHealthInstanceCall, [][]cloudhealth.FsData) {
+	return c.split()
 }
 
 type RollUpStats struct {
@@ -91,7 +96,7 @@ func (r *RollUpStats) Add(s InstanceStats) {
 	r.add(s)
 }
 
-func (r *RollUpStats) Clear() CloudHealthCall {
+func (r *RollUpStats) Clear() CloudHealthInstanceCall {
 	return r.clear()
 }
 

--- a/chpipeline/api.go
+++ b/chpipeline/api.go
@@ -1,0 +1,85 @@
+package chpipeline
+
+import (
+	"github.com/Symantec/scotty/cloudhealth"
+	"github.com/Symantec/scotty/metrics"
+	"time"
+)
+
+type FsStats struct {
+	MountPoint string
+	Size       uint64
+	Free       uint64
+}
+
+func (f *FsStats) Used() uint64 {
+	if f.Free > f.Size {
+		return 0
+	}
+	return f.Size - f.Free
+}
+
+func (f *FsStats) UsedPercent() float64 {
+	return float64(f.Used()) / float64(f.Size) * 100.0
+}
+
+type InstanceStats struct {
+	Ts               time.Time
+	UserTimeFraction float64
+	MemoryFree       uint64
+	MemoryTotal      uint64
+	Fss              []FsStats
+}
+
+func (s *InstanceStats) CPUUsedPercent() float64 {
+	// TODO: Make safe: Must return between 0 and 100.0
+	return s.UserTimeFraction * 100.0
+}
+
+func (s *InstanceStats) MemoryUsedPercent() (float64, bool) {
+	if s.MemoryTotal == 0 {
+		return 0.0, false
+	}
+	var memoryUsed uint64
+	if s.MemoryFree < s.MemoryTotal {
+		memoryUsed = s.MemoryTotal - s.MemoryFree
+	}
+	return float64(memoryUsed) / float64(s.MemoryTotal) * 100.0, true
+}
+
+func GetStats(list metrics.List) InstanceStats {
+	return InstanceStats{}
+}
+
+type CloudHealthCall struct {
+	Instances []cloudhealth.InstanceData
+	Fss       []cloudhealth.FsData
+}
+
+type RollUpStats struct {
+	instanceId        string
+	ts                time.Time
+	notEmpty          bool
+	cpuUsedPercent    cloudhealth.FVariable
+	memoryFreeBytes   cloudhealth.IVariable
+	memorySizeBytes   cloudhealth.IVariable
+	memoryUsedPercent cloudhealth.FVariable
+	// fsSizeBytes, fsUsedBytes, fsUsedPercent
+	// fss map[string]*rollUpFsStatsType
+}
+
+func NewRollUpStats(
+	instanceId string) *RollUpStats {
+	return nil
+}
+
+func (r *RollUpStats) TimeOk(t time.Time) bool {
+	return true
+}
+
+func (r *RollUpStats) Add(s InstanceStats) {
+}
+
+func (r *RollUpStats) Clear() CloudHealthCall {
+	return CloudHealthCall{}
+}

--- a/chpipeline/chpipeline.go
+++ b/chpipeline/chpipeline.go
@@ -1,9 +1,14 @@
 package chpipeline
 
 import (
+	"flag"
 	"github.com/Symantec/scotty/cloudhealth"
 	"github.com/Symantec/scotty/metrics"
 	"time"
+)
+
+var (
+	fChRollup = flag.Duration("chRollup", time.Hour, "cloudhealth rollup span for testing only")
 )
 
 func getStats(list metrics.List) InstanceStats {
@@ -117,5 +122,5 @@ func (r *RollUpStats) clear() CloudHealthCall {
 }
 
 func roundToHour(t time.Time) time.Time {
-	return t.UTC().Round(time.Hour)
+	return t.UTC().Round(*fChRollup)
 }

--- a/chpipeline/chpipeline.go
+++ b/chpipeline/chpipeline.go
@@ -1,0 +1,121 @@
+package chpipeline
+
+import (
+	"github.com/Symantec/scotty/cloudhealth"
+	"github.com/Symantec/scotty/metrics"
+	"time"
+)
+
+func getStats(list metrics.List) InstanceStats {
+	var result InstanceStats
+	// TODO: Maybe use time from remote host instead?
+	result.Ts = time.Now().UTC()
+
+	result.UserTimeFraction, _ = metrics.GetFloat64(
+		list, "/sys/sched/cpu/user-time-fraction")
+	result.MemoryFree, _ = metrics.GetUint64(list, "/sys/memory/free")
+	result.MemoryTotal, _ = metrics.GetUint64(list, "/sys/memory/total")
+
+	// TODO: This just gets the root file system. We need to report
+	// all filesystems.
+	size, _ := metrics.GetUint64(list, "/sys/fs/METRICS/size")
+	free, _ := metrics.GetUint64(list, "/sys/fs/METRICS/free")
+	if size > 0 {
+		result.Fss = []FsStats{{MountPoint: "/", Size: size, Free: free}}
+	}
+	return result
+}
+
+type rollUpFsStatsType struct {
+	isNotEmpty    bool
+	fsSizeBytes   cloudhealth.IVariable
+	fsUsedBytes   cloudhealth.IVariable
+	fsUsedPercent cloudhealth.FVariable
+}
+
+func (r *rollUpFsStatsType) IsEmpty() bool {
+	return !r.isNotEmpty
+}
+
+func (r *RollUpStats) timeOk(t time.Time) bool {
+	if r.IsEmpty() {
+		return true
+	}
+	return roundToHour(t).Equal(r.ts)
+}
+
+func (r *RollUpStats) add(s InstanceStats) {
+	if !r.timeOk(s.Ts) {
+		panic("Time not ok")
+	}
+	r.ts = roundToHour(s.Ts)
+	r.notEmpty = true
+	r.cpuUsedPercent.Add(s.CPUUsedPercent())
+	r.memoryFreeBytes.Add(s.MemoryFree)
+	r.memorySizeBytes.Add(s.MemoryTotal)
+	used, ok := s.MemoryUsedPercent()
+	if ok {
+		r.memoryUsedPercent.Add(used)
+	}
+	for _, fss := range s.Fss {
+		rollupFs := r.fss[fss.MountPoint]
+		if rollupFs == nil {
+			rollupFs = &rollUpFsStatsType{}
+			r.fss[fss.MountPoint] = rollupFs
+		}
+		rollupFs.isNotEmpty = true
+		rollupFs.fsSizeBytes.Add(fss.Size)
+		rollupFs.fsUsedBytes.Add(fss.Used())
+		usedPercent, ok := fss.UsedPercent()
+		if ok {
+			rollupFs.fsUsedPercent.Add(usedPercent)
+		}
+	}
+}
+
+func (r *RollUpStats) clear() CloudHealthCall {
+	instance := cloudhealth.InstanceData{
+		InstanceId:        r.instanceId,
+		Ts:                r.ts,
+		CpuUsedPercent:    r.cpuUsedPercent,
+		MemoryFreeBytes:   r.memoryFreeBytes,
+		MemorySizeBytes:   r.memorySizeBytes,
+		MemoryUsedPercent: r.memoryUsedPercent,
+	}
+	var fss []cloudhealth.FsData
+	for mountPoint, rollupFs := range r.fss {
+		if rollupFs.IsEmpty() {
+			continue
+		}
+		fsData := cloudhealth.FsData{
+			InstanceId:    r.instanceId,
+			MountPoint:    mountPoint,
+			Ts:            r.ts,
+			FsSizeBytes:   rollupFs.fsSizeBytes,
+			FsUsedBytes:   rollupFs.fsUsedBytes,
+			FsUsedPercent: rollupFs.fsUsedPercent,
+		}
+		fss = append(fss, fsData)
+	}
+
+	// Now clear everything
+	r.notEmpty = false
+	r.cpuUsedPercent.Clear()
+	r.memoryFreeBytes.Clear()
+	r.memorySizeBytes.Clear()
+	r.memoryUsedPercent.Clear()
+	for _, rollupFs := range r.fss {
+		rollupFs.fsSizeBytes.Clear()
+		rollupFs.fsUsedBytes.Clear()
+		rollupFs.fsUsedPercent.Clear()
+		rollupFs.isNotEmpty = false
+	}
+	return CloudHealthCall{
+		Instances: []cloudhealth.InstanceData{instance},
+		Fss:       fss,
+	}
+}
+
+func roundToHour(t time.Time) time.Time {
+	return t.UTC().Round(time.Hour)
+}

--- a/chpipeline/chpipeline.go
+++ b/chpipeline/chpipeline.go
@@ -21,12 +21,13 @@ func getStats(list metrics.List) InstanceStats {
 	result.MemoryFree, _ = metrics.GetUint64(list, "/sys/memory/free")
 	result.MemoryTotal, _ = metrics.GetUint64(list, "/sys/memory/total")
 
-	// TODO: This just gets the root file system. We need to report
-	// all filesystems.
-	size, _ := metrics.GetUint64(list, "/sys/fs/METRICS/size")
-	free, _ := metrics.GetUint64(list, "/sys/fs/METRICS/free")
-	if size > 0 {
-		result.Fss = []FsStats{{MountPoint: "/", Size: size, Free: free}}
+	fileSystems := metrics.FileSystems(list)
+	for _, fileSystem := range fileSystems {
+		size, _ := metrics.GetUint64(list, "/sys/fs/METRICS/size")
+		free, _ := metrics.GetUint64(list, "/sys/fs/METRICS/free")
+		result.Fss = append(
+			result.Fss,
+			FsStats{MountPoint: fileSystem, Size: size, Free: free})
 	}
 	return result
 }

--- a/cloudhealth/api.go
+++ b/cloudhealth/api.go
@@ -1,6 +1,7 @@
 package cloudhealth
 
 import (
+	"github.com/Symantec/scotty/lib/yamlutil"
 	"time"
 )
 
@@ -88,10 +89,19 @@ type FsData struct {
 
 // Config configures the writer
 type Config struct {
-	ApiKey        string
-	DataCenter    string // e.g us-east-1
-	AccountNumber string // 8 digit AWS account number
-	DryRun        bool   // If true, runs in dry run mode
+	ApiKey        string `yaml:"apiKey"`
+	DataCenter    string `yaml:"dataCenter"` // e.g us-east-1
+	AccountNumber string `yaml:"accountNumber"`
+	DryRun        bool   `yaml:"dryRun"` // If true, runs in dry run mode
+}
+
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type configFields Config
+	return yamlutil.StrictUnmarshalYAML(unmarshal, (*configFields)(c))
+}
+
+func (c *Config) Reset() {
+	*c = Config{}
 }
 
 type Writer struct {

--- a/cloudhealth/api.go
+++ b/cloudhealth/api.go
@@ -23,6 +23,10 @@ func (v *FVariable) Add(x float64) {
 	v.add(x)
 }
 
+func (v *FVariable) Clear() {
+	*v = FVariable{}
+}
+
 // Avg returns the average of this variable
 func (v FVariable) Avg() float64 {
 	return v.Sum / float64(v.Count)
@@ -45,6 +49,10 @@ func (v IVariable) IsEmpty() bool {
 // Add adds x to this variable
 func (v *IVariable) Add(x uint64) {
 	v.add(x)
+}
+
+func (v *IVariable) Clear() {
+	*v = IVariable{}
 }
 
 // Avg returns the average of this variable

--- a/cloudhealth/api.go
+++ b/cloudhealth/api.go
@@ -1,0 +1,78 @@
+package cloudhealth
+
+import (
+	"time"
+)
+
+// Variable represents a cloudfire variable rolled up over some amount of time
+type Variable struct {
+	Count uint64
+	Min   float64
+	Max   float64
+	Sum   float64
+}
+
+// IsEmpty returns true if no values have been added to this variable
+func (v Variable) IsEmpty() bool {
+	return v.Count == 0
+}
+
+// Add returns this variable with a new value added
+func (v Variable) Add(x float64) Variable {
+	return Variable{}
+}
+
+// Avg returns the average of this variable
+func (v Variable) Avg() float64 {
+	return v.Sum / float64(v.Count)
+}
+
+const InstanceDataPointCount = 12 // 4 variables * (min,max,avg)
+
+// InstanceData contains rolled up data for a particular instance
+type InstanceData struct {
+	InstanceId        string    // The aws instance ID
+	Ts                time.Time // The timestamp at one hour granularity
+	CpuUsedPercent    Variable
+	MemoryFreeBytes   Variable
+	MemorySizeBytes   Variable
+	MemoryUsedPercent Variable
+}
+
+const FSDataPointCount = 9 // 3 variables * (min,max,avg)
+
+// FsData contains rolled up data for a particular file system
+type FsData struct {
+	InstanceId    string    // the aws instance ID
+	MountPoint    string    // The mount point of file system
+	Ts            time.Time // The timestamp at one hour granularity
+	FsSizeBytes   Variable
+	FsUsedBytes   Variable
+	FsUsedPercent Variable
+}
+
+// Config configures the writer
+type Config struct {
+	ApiKey        string
+	DataCenter    string // e.g us-east-1
+	AccountNumber string // 8 digit AWS account number
+	DryRun        bool   // If true, runs in dry run mode
+}
+
+type Writer struct {
+	config Config
+}
+
+// Write writes the provided data in a single request.
+// Write panics if the number of data points exceeds 1000. That is,
+// len(instances)*InstanceDataPointCount + len(fss)*FsDataPointCount >= 1000.
+// Write returns the http response code along with an error if applicable.
+// If the write is parital success, Write returns 200 along with the error.
+// Write will never return a 429 response. If Write receives a 429, it
+// retries using exponential backoff internally until it receives a non
+// 429 response and returns that.
+func (w *Writer) Write(
+	instances []InstanceData, fss []FsData) (
+	responseCode int, err error) {
+	return
+}

--- a/cloudhealth/variable.go
+++ b/cloudhealth/variable.go
@@ -1,0 +1,37 @@
+package cloudhealth
+
+func (v *FVariable) add(x float64) {
+	if v.Count == 0 {
+		v.Count = 1
+		v.Min = x
+		v.Max = x
+		v.Sum = x
+		return
+	}
+	v.Count++
+	if x < v.Min {
+		v.Min = x
+	}
+	if x > v.Max {
+		v.Max = x
+	}
+	v.Sum += x
+}
+
+func (v *IVariable) add(x uint64) {
+	if v.Count == 0 {
+		v.Count = 1
+		v.Min = x
+		v.Max = x
+		v.Sum = x
+		return
+	}
+	v.Count++
+	if x < v.Min {
+		v.Min = x
+	}
+	if x > v.Max {
+		v.Max = x
+	}
+	v.Sum += x
+}

--- a/cloudhealth/writer.go
+++ b/cloudhealth/writer.go
@@ -1,0 +1,245 @@
+package cloudhealth
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/Symantec/scotty/lib/httputil"
+	"net/http"
+	"time"
+)
+
+type metaDataType struct {
+	AssetType   string   `json:"assetType"`
+	Granularity string   `json:"granularity"`
+	Keys        []string `json:"keys"`
+}
+
+type datasetType struct {
+	Metadata *metaDataType   `json:"metadata"`
+	Values   [][]interface{} `json:"values"`
+}
+
+type metricType struct {
+	Datasets []datasetType `json:"datasets"`
+}
+
+type requestType struct {
+	Metrics metricType `json:"metrics"`
+}
+
+var kInstance = &metaDataType{
+	AssetType:   "aws:ec2:instance",
+	Granularity: "hour",
+	Keys: []string{
+		"assetId",
+		"timestamp",
+		"cpu:used:percent.avg",
+		"cpu:used:percent.max",
+		"cpu:used:percent.min",
+		"memory:free:bytes.avg",
+		"memory:free:bytes.max",
+		"memory:free:bytes.min",
+		"memory:size:bytes.avg",
+		"memory:size:bytes.max",
+		"memory:size:bytes.min",
+		"memory:used:percent.avg",
+		"memory:used:percent.max",
+		"memory:used:percent.min",
+	},
+}
+
+var kFs = &metaDataType{
+	AssetType:   "aws:ec2:instance:fs",
+	Granularity: "hour",
+	Keys: []string{
+		"assetId",
+		"timestamp",
+		"fs:size:bytes.avg",
+		"fs:size:bytes.max",
+		"fs:size:bytes.min",
+		"fs:used:bytes.avg",
+		"fs:used:bytes.max",
+		"fs:used:bytes.min",
+		"fs:used:percent.avg",
+		"fs:used:percent.max",
+		"fs:used:percent.min",
+	},
+}
+
+type chResponseType struct {
+	Succeeded int `json:"succeeded"`
+	Failed    int `json:"failed"`
+	Errors    int `json:"errors"`
+}
+
+func (v FVariable) toValues() (avg, max, min interface{}) {
+	if v.Count == 0 {
+		return
+	}
+	return v.Avg(), v.Max, v.Min
+}
+
+func (v IVariable) toValues() (avg, max, min interface{}) {
+	if v.Count == 0 {
+		return
+	}
+	return v.Avg(), v.Max, v.Min
+}
+
+func toTsValue(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05-07:00")
+}
+
+func (d *InstanceData) toValues(
+	dataCenter, accountNumber string) []interface{} {
+	assetId := fmt.Sprintf(
+		"%s:%s:%s", dataCenter, accountNumber, d.InstanceId)
+	cpuUsedPercentAvg, cpuUsedPercentMax, cpuUsedPercentMin :=
+		d.CpuUsedPercent.toValues()
+	memoryFreeBytesAvg, memoryFreeBytesMax, memoryFreeBytesMin :=
+		d.MemoryFreeBytes.toValues()
+	memorySizeBytesAvg, memorySizeBytesMax, memorySizeBytesMin :=
+		d.MemorySizeBytes.toValues()
+	memoryUsedPercentAvg, memoryUsedPercentMax, memoryUsedPercentMin :=
+		d.MemoryUsedPercent.toValues()
+	return []interface{}{
+		assetId,
+		toTsValue(d.Ts),
+		cpuUsedPercentAvg,
+		cpuUsedPercentMax,
+		cpuUsedPercentMin,
+		memoryFreeBytesAvg,
+		memoryFreeBytesMax,
+		memoryFreeBytesMin,
+		memorySizeBytesAvg,
+		memorySizeBytesMax,
+		memorySizeBytesMin,
+		memoryUsedPercentAvg,
+		memoryUsedPercentMax,
+		memoryUsedPercentMin,
+	}
+}
+
+func (d *FsData) toValues(
+	dataCenter, accountNumber string) []interface{} {
+	assetId := fmt.Sprintf(
+		"%s:%s:%s:%s",
+		dataCenter,
+		accountNumber,
+		d.InstanceId,
+		d.MountPoint)
+	fsSizeBytesAvg, fsSizeBytesMax, fsSizeBytesMin :=
+		d.FsSizeBytes.toValues()
+	fsUsedBytesAvg, fsUsedBytesMax, fsUsedBytesMin :=
+		d.FsUsedBytes.toValues()
+	fsUsedPercentAvg, fsUsedPercentMax, fsUsedPercentMin :=
+		d.FsUsedPercent.toValues()
+	return []interface{}{
+		assetId,
+		toTsValue(d.Ts),
+		fsSizeBytesAvg,
+		fsSizeBytesMax,
+		fsSizeBytesMin,
+		fsUsedBytesAvg,
+		fsUsedBytesMax,
+		fsUsedBytesMin,
+		fsUsedPercentAvg,
+		fsUsedPercentMax,
+		fsUsedPercentMin,
+	}
+}
+
+func (w *Writer) buildRequest(
+	instances []InstanceData, fss []FsData) ([]byte, error) {
+	var metrics []datasetType
+	if len(instances) > 0 {
+		instanceValues := make([][]interface{}, len(instances))
+		for i := range instances {
+			instanceValues[i] = instances[i].toValues(
+				w.config.DataCenter, w.config.AccountNumber)
+		}
+		metrics = append(
+			metrics,
+			datasetType{
+				Metadata: kInstance,
+				Values:   instanceValues,
+			})
+	}
+	if len(fss) > 0 {
+		fsValues := make([][]interface{}, len(fss))
+		for i := range fss {
+			fsValues[i] = fss[i].toValues(
+				w.config.DataCenter, w.config.AccountNumber)
+		}
+		metrics = append(
+			metrics,
+			datasetType{
+				Metadata: kFs,
+				Values:   fsValues,
+			})
+	}
+	return json.MarshalIndent(
+		&requestType{
+			Metrics: metricType{
+				Datasets: metrics,
+			},
+		}, "", "\t")
+}
+
+func (w *Writer) write(
+	instances []InstanceData, fss []FsData) (int, error) {
+	if len(instances)*InstanceDataPointCount+len(fss)*FsDataPointCount > MaxDataPoints {
+		panic("Too many data points")
+	}
+	body, err := w.buildRequest(instances, fss)
+	if err != nil {
+		return 0, err
+	}
+	url := httputil.NewUrl(
+		"https://chapi.cloudhealthtech.com/metrics/v1",
+		"api_key",
+		w.config.ApiKey)
+	if w.config.DryRun {
+		url = httputil.AppendParams(
+			url,
+			"dryrun",
+			"true")
+	}
+	urlStr := url.String()
+	var client http.Client
+	resp, err := client.Post(
+		urlStr, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return 0, err
+	}
+	respCode, err := parseResponse(resp)
+	delay := 20 * time.Millisecond
+	for respCode == 429 {
+		time.Sleep(delay)
+		delay *= 2
+		resp, err = client.Post(
+			urlStr, "application/json", bytes.NewBuffer(body))
+		if err != nil {
+			return 0, err
+		}
+		respCode, err = parseResponse(resp)
+	}
+	return respCode, err
+}
+
+func parseResponse(resp *http.Response) (int, error) {
+	defer resp.Body.Close()
+	var buffer bytes.Buffer
+	buffer.ReadFrom(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return resp.StatusCode, errors.New(buffer.String())
+	}
+	var chResponse chResponseType
+	json.Unmarshal(buffer.Bytes(), &chResponse)
+	if chResponse.Failed > 0 || chResponse.Errors > 0 {
+		return resp.StatusCode, errors.New(buffer.String())
+	}
+	return resp.StatusCode, nil
+}

--- a/init.d/scotty.Debian-7
+++ b/init.d/scotty.Debian-7
@@ -97,7 +97,7 @@ do_start ()
 {
     start-stop-daemon --start --quiet --pidfile "$PIDFILE" \
 		      --exec "$DAEMON" --chuid "$USERNAME" --make-pidfile -- \
-		      $PROG_ARGS
+		      $PROG_ARGS &> /home/travis_keep/scotty_out.txt
 }
 
 start_loop ()

--- a/lib/httputil/api.go
+++ b/lib/httputil/api.go
@@ -11,3 +11,11 @@ import (
 func NewUrl(path string, nameValues ...string) *url.URL {
 	return newUrl(path, nameValues)
 }
+
+// AppendParams returns a URL with new parameters appended. No existing
+// parameter is replaced. u is the original URL; nameValues is
+// parameter name, parameter value, parameter name, parameter
+// value, etc. nameValues must have even length.
+func AppendParams(u *url.URL, nameValues ...string) *url.URL {
+	return appendParams(u, nameValues)
+}

--- a/lib/httputil/httputil.go
+++ b/lib/httputil/httputil.go
@@ -17,3 +17,17 @@ func newUrl(path string, nameValues []string) *url.URL {
 		Path:     path,
 		RawQuery: values.Encode()}
 }
+
+func appendParams(u *url.URL, nameValues []string) *url.URL {
+	length := len(nameValues)
+	if length%2 != 0 {
+		panic("nameValues must have even length.")
+	}
+	result := *u
+	values := result.Query()
+	for i := 0; i < length; i += 2 {
+		values.Add(nameValues[i], nameValues[i+1])
+	}
+	result.RawQuery = values.Encode()
+	return &result
+}

--- a/metrics/api.go
+++ b/metrics/api.go
@@ -52,6 +52,18 @@ func Find(list List, path string) int {
 	return find(list, path)
 }
 
+// GetFloat64 gets the float64 value at path.
+// GetFloat64 returns false if path doesn't exist or if value is not float64.
+func GetFloat64(list List, path string) (float64, bool) {
+	return getFloat64(list, path)
+}
+
+// GetUint64 gets the Uint64 value at path.
+// GetUint64 returns false if path doesn't exist or if value is not uint64.
+func GetUint64(list List, path string) (uint64, bool) {
+	return getUint64(list, path)
+}
+
 // VerifyList verifies that the given list adheres to the specification.
 func VerifyList(list List) error {
 	return verifyList(list)

--- a/metrics/api.go
+++ b/metrics/api.go
@@ -52,6 +52,13 @@ func Find(list List, path string) int {
 	return find(list, path)
 }
 
+// FileSystems returns all the distinct file systems mount points in the list.
+// A metric for file system with mount point "/some/filesystem" would look
+// like "/sys/fs/some/filesystem/METRICS/some/metric"
+func FileSystems(list List) []string {
+	return fileSystems(list)
+}
+
 // GetFloat64 gets the float64 value at path.
 // GetFloat64 returns false if path doesn't exist or if value is not float64.
 func GetFloat64(list List, path string) (float64, bool) {
@@ -81,7 +88,7 @@ func (s SimpleList) Index(i int, value *Value) {
 }
 
 func (s SimpleList) Less(i, j int) bool {
-	return comparePaths(s[i].Path, s[j].Path) < 0
+	return comparePaths(newPath(s[i].Path), newPath(s[j].Path)) < 0
 }
 
 func (s SimpleList) Swap(i, j int) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -43,6 +43,37 @@ func find(list List, path string) int {
 	})
 }
 
+func get(list List, path string) (interface{}, bool) {
+	index := Find(list, path)
+	if index == list.Len() {
+		return nil, false
+	}
+	var value Value
+	list.Index(index, &value)
+	if value.Path != path {
+		return nil, false
+	}
+	return value.Value, true
+}
+
+func getFloat64(list List, path string) (float64, bool) {
+	val, ok := get(list, path)
+	if !ok {
+		return 0.0, false
+	}
+	v, k := val.(float64)
+	return v, k
+}
+
+func getUint64(list List, path string) (uint64, bool) {
+	val, ok := get(list, path)
+	if !ok {
+		return 0, false
+	}
+	v, k := val.(uint64)
+	return v, k
+}
+
 func verifyList(list List) error {
 	length := list.Len()
 	pathSet := make(map[string]bool, length)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -2,6 +2,7 @@ package metrics_test
 
 import (
 	"github.com/Symantec/scotty/metrics"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -201,28 +202,16 @@ func TestDiffTimeStampDiffGroupOk(t *testing.T) {
 func TestFind(t *testing.T) {
 	list := metrics.SimpleList{
 		{
-			Path:      "bar",
-			Value:     int64(0),
-			TimeStamp: kNow,
-			GroupId:   0,
+			Path: "bar",
 		},
 		{
-			Path:      "baz",
-			Value:     int64(0),
-			TimeStamp: kNow,
-			GroupId:   0,
+			Path: "baz",
 		},
 		{
-			Path:      "foo",
-			Value:     int64(0),
-			TimeStamp: kNow,
-			GroupId:   0,
+			Path: "foo",
 		},
 		{
-			Path:      "yyyy",
-			Value:     int64(0),
-			TimeStamp: kNow,
-			GroupId:   0,
+			Path: "yyyy",
 		},
 	}
 	if out := metrics.Find(list, "a"); out != 0 {
@@ -233,5 +222,60 @@ func TestFind(t *testing.T) {
 	}
 	if out := metrics.Find(list, "zzz"); out != 4 {
 		t.Errorf("Expected 4, got %d", out)
+	}
+}
+
+func TestChildren(t *testing.T) {
+	list := metrics.SimpleList{
+		{
+			Path: "/proc/fs/x/METRICS/free",
+		},
+		{
+			Path: "/sys/fs/METRICS/free",
+		},
+		{
+			Path: "/sys/fs/METRICS/size",
+		},
+		{
+			Path: "/sys/fs/a",
+		},
+		{
+			Path: "/sys/fs/boot/METRICS/free",
+		},
+		{
+			Path: "/sys/fs/boot/a/METRICS/b",
+		},
+		{
+			Path: "/sys/fs/boot/a/METRICS/free",
+		},
+		{
+			Path: "/sys/fs/boot/a/METRICS/size",
+		},
+		{
+			Path: "/sys/fs/boot/b/METRICS/size",
+		},
+		{
+			Path: "/sys/fs/boot/a/y",
+		},
+		{
+			Path: "/sys/fs/main/METRICS/free",
+		},
+		{
+			Path: "/sys/fs/main/METRICS/size/x",
+		},
+		{
+			Path: "/sys/net/blow/METRICS/size",
+		},
+	}
+	actual := metrics.FileSystems(list)
+	expected := []string{
+		"/",
+		"/boot",
+		"/boot/a",
+		"/boot/b",
+		"/main",
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Expected %v; got %v", expected, actual)
 	}
 }


### PR DESCRIPTION
Hi richard. This is my first shot at Go API for writing to cloud health. Please let me know what you think.

I am realizing that I cannot use the pstore framework to write to cloud health. The unit of data for writing to cloud health is the asset ID which depicts either an instance or a file system on an instance. The unit of data in the pstore framework is an individual metric value. 

solution:

Use a solution similar to how we write to CIS by capturing the data as soon as we collect it.
For each instance and filesystem we would have to keep a running total of aggregated data over the last hour.
