### PR TITLE
Fix bug in scotty paging.

### DIFF
--- a/store/pageseries.go
+++ b/store/pageseries.go
@@ -342,6 +342,7 @@ func (t *timestampSeriesType) Inactivate() (
 		return
 	}
 	neededToAdd = true
+	actualTs = incTs(t.lastTs)
 	lastPage, isNew := t.pages.LastPageMustHaveSpace(nil)
 	if lastPage == nil {
 		return
@@ -354,7 +355,6 @@ func (t *timestampSeriesType) Inactivate() (
 	latestPage := lastPage.Times()
 	latestPage.Add(t.lastTs)
 	t.lastTs = incTs(t.lastTs)
-	actualTs = t.lastTs
 	return
 }
 


### PR DESCRIPTION
Problem timestampSeriesType.Inactivate() would return a zero timestamp
If a new page is needed to store the inactive timestamp. This in turn
would introduce zero timestamps in the btree thereby corrupting it.

This fix makes timestampSeriesType.Inactivate() return a valid timestamp
even if a new page is needed to store the inactive timestamp.