### PR TITLE
Add Snapshot to chpipeline.

### DIFF
--- a/apps/scotty/collect.go
+++ b/apps/scotty/collect.go
@@ -208,7 +208,7 @@ func (l *loggerType) LogResponse(
 			if l.CloudHealthChannel != nil && l.CloudHealthStats != nil {
 				stats := chpipeline.GetStats(list)
 				if l.CombineFileSystems {
-					stats.CombineFsStats()
+					stats = stats.WithCombinedFsStats()
 				}
 				if !l.CloudHealthStats.TimeOk(stats.Ts) {
 					l.CloudHealthChannel <- l.CloudHealthStats.CloudHealth()

--- a/chpipeline/chpipeline_test.go
+++ b/chpipeline/chpipeline_test.go
@@ -138,8 +138,7 @@ func TestFileSystemStats(t *testing.T) {
 			So(expected, ShouldResemble, stats.Fss)
 		})
 		Convey("combined file system stats", func() {
-			stats := chpipeline.GetStats(list)
-			stats.CombineFsStats()
+			stats := chpipeline.GetStats(list).WithCombinedFsStats()
 			expected := []chpipeline.FsStats{
 				{
 					MountPoint: "/",


### PR DESCRIPTION
Along with new methods on RollUpStats.

Snapshot is designed to be generic, not tightly coupled to any
particular storage system.