### PR TITLE
Let cloudwatch.Config specify location of shared credentials file.

### DIFF
--- a/cloudwatch/api.go
+++ b/cloudwatch/api.go
@@ -25,6 +25,13 @@ func (a *AwsRole) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type Config struct {
 	Roles []AwsRole `yaml:"roles"`
 
+	// Full path of AWS shared credentials file
+	SharedCredentialsFile string `yaml:"sharedCredentialsFile"`
+
+	// The AWS profile name to use in shared credentials file.
+	// Omitting this is equivalent to specifying the "default" profile
+	SharedCredentialsProfile string `yaml:"sharedCredentialsProfile"`
+
 	// looks like "us-east-1", "us-west-2", etc.
 	Region string `yaml:"region"`
 }

--- a/cloudwatch/writer.go
+++ b/cloudwatch/writer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/Symantec/scotty/chpipeline"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
@@ -17,6 +18,8 @@ func newWriter(c Config) (*Writer, error) {
 	sess, err := session.NewSessionWithOptions(
 		session.Options{
 			Config: aws.Config{
+				Credentials: credentials.NewSharedCredentials(
+					c.SharedCredentialsFile, c.SharedCredentialsProfile),
 				Region: aws.String(c.Region)}})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This way the shared credentials file doesn't have to be in users home directory. It can live in /etc/scotty along with the other scotty config files.