### PR TITLE
Minor changes to cloudwatch:

### DIFF
--- a/apps/scotty/collect.go
+++ b/apps/scotty/collect.go
@@ -209,11 +209,13 @@ func (l *loggerType) LogResponse(
 			}
 		}
 		var stats chpipeline.InstanceStats
+		var combinedFsStats chpipeline.InstanceStats
 		var statsOk bool
 		chRollup := l.EndpointData.CHRollup
 		if l.CloudHealthChannel != nil && chRollup != nil {
 			if !statsOk {
 				stats = chpipeline.GetStats(list)
+				combinedFsStats = stats.WithCombinedFsStats()
 				statsOk = true
 			}
 			if !chRollup.TimeOk(stats.Ts) {
@@ -221,7 +223,7 @@ func (l *loggerType) LogResponse(
 				chRollup.Clear()
 			}
 			if l.EndpointData.CHCombineFS {
-				chRollup.Add(stats.WithCombinedFsStats())
+				chRollup.Add(combinedFsStats)
 			} else {
 				chRollup.Add(stats)
 			}
@@ -230,13 +232,14 @@ func (l *loggerType) LogResponse(
 		if l.CloudWatchChannel != nil && cwRollup != nil {
 			if !statsOk {
 				stats = chpipeline.GetStats(list)
+				combinedFsStats = stats.WithCombinedFsStats()
 				statsOk = true
 			}
 			if !cwRollup.TimeOk(stats.Ts) {
 				l.CloudWatchChannel <- cwRollup.TakeSnapshot()
 				cwRollup.Clear()
 			}
-			cwRollup.Add(stats)
+			cwRollup.Add(combinedFsStats)
 		}
 	}
 	// This error just means that the endpoint was marked inactive

--- a/cloudwatch/writer.go
+++ b/cloudwatch/writer.go
@@ -40,6 +40,11 @@ func (w *Writer) write(snapshot *chpipeline.Snapshot) error {
 	if !ok {
 		return fmt.Errorf("Unrecognizsed account: %s", snapshot.AccountNumber)
 	}
+	if len(snapshot.Fss) > 1 {
+		return fmt.Errorf(
+			"multiple file systems not supported. found %d",
+			len(snapshot.Fss))
+	}
 	_, err := serviceClients.CloudWatch.PutMetricData(
 		toPutMetricData(snapshot))
 	return err

--- a/datastructs/api.go
+++ b/datastructs/api.go
@@ -61,10 +61,10 @@ func (e *EndpointData) UpdateForCloudHealth(
 //
 // If nothing changed, UpdateForCloudWatch just returns e.
 //
-// If the endpoint's machine has an AWS tag called CloudWatchRate, the time
-// in there is the roll up time to use. If the tag exists but the value is
-// missing, that means use defaultFreq for the rollup time. If the tag
-// doesn't exist, that means don't collect data for cloud watch.
+// If the endpoint's machine has an AWS tag called PushMetricsToCloudWatch,
+// the time in there is the roll up time to use. If the tag exists but the
+// value is missing, that means use defaultFreq for the rollup time. If
+// the tag doesn't exist, that means don't collect data for cloud watch.
 func (e *EndpointData) UpdateForCloudWatch(
 	app *ApplicationStatus, defaultFreq time.Duration) *EndpointData {
 	return e.updateForCloudWatch(app, defaultFreq)

--- a/datastructs/endpointdata.go
+++ b/datastructs/endpointdata.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	kCloudWatchRate = "CloudWatchRate"
+	kCloudWatchRate = "PushMetricsToCloudWatch"
 )
 
 func (e *EndpointData) updateForCloudHealth(

--- a/datastructs/endpointdata_test.go
+++ b/datastructs/endpointdata_test.go
@@ -56,7 +56,7 @@ func TestEndpointData(t *testing.T) {
 					AccountId:  "2468",
 					InstanceId: "1357",
 					Tags: map[string]string{
-						"CloudWatchRate": "2m",
+						"PushMetricsToCloudWatch": "2m",
 					},
 				},
 			}
@@ -88,7 +88,7 @@ func TestEndpointData(t *testing.T) {
 							AccountId:  "2468",
 							InstanceId: "1357",
 							Tags: map[string]string{
-								"CloudWatchRate": "",
+								"PushMetricsToCloudWatch": "",
 							},
 						},
 					}
@@ -104,7 +104,7 @@ func TestEndpointData(t *testing.T) {
 							AccountId:  "2468",
 							InstanceId: "1357",
 							Tags: map[string]string{
-								"CloudWatchRate": "3m",
+								"PushMetricsToCloudWatch": "3m",
 							},
 						},
 					}


### PR DESCRIPTION
- Combine file descriptor metrics
- Only 3 metrics to cloudwatch: CPU %, memory %, file system %.
- Use tag PushMetricsToCloudWatch tag instead of CloudWatchRate
- Capital S Scotty namespace name
- Remove MountPoint dimension