### PR TITLE
Get rid of duplicate constant for cloudwatch tag name.

### DIFF
--- a/datastructs/datastructs.go
+++ b/datastructs/datastructs.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-const kCloudWatchTag = "CloudWatchRefreshRate"
+const kCloudWatchTag = "PushMetricsToCloudWatch"
 
 type byHostAndName []*ApplicationStatus
 
@@ -83,7 +83,7 @@ func (a *ApplicationStatus) instanceId() string {
 
 func (a *ApplicationStatus) cloudWatch() string {
 	if a.Aws != nil {
-		if result, ok := a.Aws.Tags[kCloudWatchRate]; ok {
+		if result, ok := a.Aws.Tags[kCloudWatchTag]; ok {
 			if _, err := time.ParseDuration(result); err != nil {
 				return "defaultRate"
 			}

--- a/datastructs/datastructs_test.go
+++ b/datastructs/datastructs_test.go
@@ -204,7 +204,7 @@ func TestCloudWatchRefreshRate(t *testing.T) {
 					Hostname: "host101",
 					AwsMetadata: &mdb.AwsMetadata{
 						Tags: map[string]string{
-							"CloudWatchRefreshRate": "4m",
+							"PushMetricsToCloudWatch": "4m",
 						},
 					},
 				},
@@ -212,7 +212,7 @@ func TestCloudWatchRefreshRate(t *testing.T) {
 					Hostname: "host102",
 					AwsMetadata: &mdb.AwsMetadata{
 						Tags: map[string]string{
-							"CloudWatchRefreshRate": "",
+							"PushMetricsToCloudWatch": "",
 						},
 					},
 				},

--- a/datastructs/endpointdata.go
+++ b/datastructs/endpointdata.go
@@ -5,10 +5,6 @@ import (
 	"time"
 )
 
-const (
-	kCloudWatchRate = "PushMetricsToCloudWatch"
-)
-
 func (e *EndpointData) updateForCloudHealth(
 	app *ApplicationStatus, combineFsMap map[string]bool) *EndpointData {
 	// If we don't have any aws data don't do anything
@@ -33,19 +29,7 @@ func (e *EndpointData) updateForCloudHealth(
 
 func (e *EndpointData) updateForCloudWatch(
 	app *ApplicationStatus, defaultFreq time.Duration) *EndpointData {
-	// If we don't have any aws data don't do anything
-	if app.Aws == nil {
-		return e
-	}
-	rateStr, rateOk := app.Aws.Tags[kCloudWatchRate]
-	var rate time.Duration
-	if rateOk {
-		var err error
-		rate, err = time.ParseDuration(rateStr)
-		if err != nil {
-			rate = defaultFreq
-		}
-	}
+	rate, rateOk := app.CloudWatchRefreshRate(defaultFreq)
 	cwExists := e.CWRollup != nil
 
 	// Calling RoundDuration() here is safe because its returned value never


### PR DESCRIPTION
Get rid of duplicate code to extract value of cloud watch tag.