### PR TITLE
Remove chpipeline.RollUpStats.CloudHealth function.

### DIFF
--- a/chpipeline/api.go
+++ b/chpipeline/api.go
@@ -89,6 +89,12 @@ type CloudHealthInstanceCall struct {
 	Fss      []cloudhealth.FsData     // Data for each file system in instance
 }
 
+// NewCloudHealthInstanceCall creates a new CloudHealthInstanceCall from a
+// Snapshot.
+func NewCloudHealthInstanceCall(s *Snapshot) CloudHealthInstanceCall {
+	return newCloudHealthInstanceCall(s)
+}
+
 // Split splits this call into smaller calls that are below the maximum size
 // for writing to cloudhealth.
 // If c is small enough, then split returns c, nil. If c is too big,
@@ -171,13 +177,6 @@ func (r *RollUpStats) Add(s InstanceStats) {
 // TakeSnapshot grabs a snapshot of this instance
 func (r *RollUpStats) TakeSnapshot() *Snapshot {
 	return r.takeSnapshot()
-}
-
-// CloudHealth returns the call needed to write the data in this instance to
-// cloud health.
-// CloudHealth panics if Add has not been called since the last call to Clear.
-func (r *RollUpStats) CloudHealth() CloudHealthInstanceCall {
-	return r.cloudHealth()
 }
 
 // Clear clears this instance

--- a/chpipeline/chpipeline.go
+++ b/chpipeline/chpipeline.go
@@ -176,8 +176,7 @@ func (r *RollUpStats) takeSnapshot() *Snapshot {
 	}
 }
 
-func (r *RollUpStats) cloudHealth() CloudHealthInstanceCall {
-	snapshot := r.takeSnapshot()
+func newCloudHealthInstanceCall(snapshot *Snapshot) CloudHealthInstanceCall {
 	instance := cloudhealth.InstanceData{
 		AccountNumber:     snapshot.AccountNumber,
 		InstanceId:        snapshot.InstanceId,

--- a/chpipeline/chpipeline_test.go
+++ b/chpipeline/chpipeline_test.go
@@ -282,7 +282,8 @@ func TestRollUp(t *testing.T) {
 		So(rollup.TimeOk(kToday.Add(15*time.Hour)), ShouldBeFalse)
 		So(func() { rollup.Add(stats4) }, ShouldPanic)
 		Convey("Rollup successful", func() {
-			chInstanceCall := rollup.CloudHealth()
+			chInstanceCall := chpipeline.NewCloudHealthInstanceCall(
+				rollup.TakeSnapshot())
 			instance := chInstanceCall.Instance
 			So(
 				instance.AccountNumber,
@@ -335,7 +336,7 @@ func TestRollUp(t *testing.T) {
 		})
 		Convey("Clear works", func() {
 			rollup.Clear()
-			So(func() { rollup.CloudHealth() }, ShouldPanic)
+			So(func() { rollup.TakeSnapshot() }, ShouldPanic)
 			stats4 := chpipeline.InstanceStats{
 				Ts: kToday.Add(15 * time.Hour),
 				MemoryTotal: chpipeline.MaybeUint64{
@@ -344,7 +345,8 @@ func TestRollUp(t *testing.T) {
 				},
 			}
 			rollup.Add(stats4)
-			chInstanceCall := rollup.CloudHealth()
+			chInstanceCall := chpipeline.NewCloudHealthInstanceCall(
+				rollup.TakeSnapshot())
 			instance := chInstanceCall.Instance
 			So(
 				instance.MemorySizeBytes.Avg(),


### PR DESCRIPTION
The RollUpStats instance shouldn't be tightly coupled to any particular
system. Instead RollUpStats instances should produce only Snapshot
instances. The advantage here is that we only need to persist Snapshot
instances rather than instances specific to a particular metrics storage
system like cloud health.