### PR TITLE
Introduce "ForScottyTest" AWS tag.

### DIFF
--- a/apps/scotty/collect.go
+++ b/apps/scotty/collect.go
@@ -57,6 +57,8 @@ var (
 		"cloudWatchFreq",
 		5*time.Minute,
 		"Rollup time for cloudwatch")
+	fTestInstance = flag.Bool(
+		"testInstance", false, "Whether or not this is a test instance.")
 )
 
 func init() {
@@ -444,11 +446,11 @@ func startCollector(
 				if endpoint.Port() == 6910 {
 					if cloudHealthChannel != nil {
 						endpointData = endpointData.UpdateForCloudHealth(
-							app, combineFsMap)
+							app, combineFsMap, *fTestInstance)
 					}
 					if cloudWatchChannel != nil {
 						endpointData = endpointData.UpdateForCloudWatch(
-							app, *fCloudWatchFreq)
+							app, *fCloudWatchFreq, *fTestInstance)
 					}
 				}
 				endpointToData[endpoint] = endpointData

--- a/datastructs/api.go
+++ b/datastructs/api.go
@@ -47,12 +47,15 @@ func NewEndpointData() *EndpointData {
 // collect cloud health data. app represents the endpoint; combineFsMap
 // is a map of instance ids for which file system metrics should be rolled up.
 // A nil map means file system metrics should be rolled up for all instance Ids.
-// An empty map means file system metrics should never be rolled up.
+// An empty map means file system metrics should never be rolled up. bTestRun
+// is true if this is a test instance of scotty.
 //
 // If nothing changed, UpdateForCloudHealth just returns e.
 func (e *EndpointData) UpdateForCloudHealth(
-	app *ApplicationStatus, combineFsMap map[string]bool) *EndpointData {
-	return e.updateForCloudHealth(app, combineFsMap)
+	app *ApplicationStatus,
+	combineFsMap map[string]bool,
+	bTestRun bool) *EndpointData {
+	return e.updateForCloudHealth(app, combineFsMap, bTestRun)
 }
 
 // UpdateForCloudWatch returns a new EndpointData instance set up to collect
@@ -65,9 +68,12 @@ func (e *EndpointData) UpdateForCloudHealth(
 // the time in there is the roll up time to use. If the tag exists but the
 // value is missing, that means use defaultFreq for the rollup time. If
 // the tag doesn't exist, that means don't collect data for cloud watch.
+// bTestRun is true if this is a test instance of scotty.
 func (e *EndpointData) UpdateForCloudWatch(
-	app *ApplicationStatus, defaultFreq time.Duration) *EndpointData {
-	return e.updateForCloudWatch(app, defaultFreq)
+	app *ApplicationStatus,
+	defaultFreq time.Duration,
+	bTestRun bool) *EndpointData {
+	return e.updateForCloudWatch(app, defaultFreq, bTestRun)
 }
 
 // ApplicationStatus represents the status of a single application.
@@ -114,6 +120,12 @@ func (a *ApplicationStatus) AccountNumber() string {
 // or the empty string if machine is not an AWS machine.
 func (a *ApplicationStatus) InstanceId() string {
 	return a.instanceId()
+}
+
+// ForTest returns true iff the machine of this endpoint is for testing
+// scotty
+func (a *ApplicationStatus) ForTest() bool {
+	return a.forTest()
 }
 
 // CloudWatch returns how often data for the machine gets written to

--- a/datastructs/datastructs.go
+++ b/datastructs/datastructs.go
@@ -18,6 +18,7 @@ import (
 )
 
 const kCloudWatchTag = "PushMetricsToCloudWatch"
+const kForScottyTestTag = "ForScottyTest"
 
 var (
 	kDurationTooSmall = errors.New("Duration too small")
@@ -94,6 +95,14 @@ func parseDuration(durStr string) (time.Duration, error) {
 		return 0, kDurationTooSmall
 	}
 	return dur, nil
+}
+
+func (a *ApplicationStatus) forTest() bool {
+	if a.Aws != nil {
+		_, ok := a.Aws.Tags[kForScottyTestTag]
+		return ok
+	}
+	return false
 }
 
 func (a *ApplicationStatus) cloudWatch() string {

--- a/datastructs/endpointdata.go
+++ b/datastructs/endpointdata.go
@@ -6,13 +6,22 @@ import (
 )
 
 func (e *EndpointData) updateForCloudHealth(
-	app *ApplicationStatus, combineFsMap map[string]bool) *EndpointData {
+	app *ApplicationStatus,
+	combineFsMap map[string]bool,
+	bTestRun bool) *EndpointData {
 	// If we don't have any aws data don't do anything
 	if app.Aws == nil {
 		return e
 	}
-	if e.CHRollup == nil {
+	needToDoCloudHealth := bTestRun == app.ForTest()
+	doingCloudHealth := e.CHRollup != nil
+	if needToDoCloudHealth != doingCloudHealth {
 		result := *e
+		if !needToDoCloudHealth {
+			result.CHRollup = nil
+			result.CHCombineFS = false
+			return &result
+		}
 		instanceId := app.InstanceId()
 		result.CHRollup = chpipeline.NewRollUpStats(
 			app.AccountNumber(),
@@ -28,8 +37,11 @@ func (e *EndpointData) updateForCloudHealth(
 }
 
 func (e *EndpointData) updateForCloudWatch(
-	app *ApplicationStatus, defaultFreq time.Duration) *EndpointData {
+	app *ApplicationStatus,
+	defaultFreq time.Duration,
+	bTestRun bool) *EndpointData {
 	rate, rateOk := app.CloudWatchRefreshRate(defaultFreq)
+	rateOk = rateOk && (bTestRun == app.ForTest())
 	cwExists := e.CWRollup != nil
 
 	// Calling RoundDuration() here is safe because its returned value never

--- a/datastructs/endpointdata_test.go
+++ b/datastructs/endpointdata_test.go
@@ -12,6 +12,34 @@ func TestEndpointData(t *testing.T) {
 	Convey("With EndpointData", t, func() {
 		data := datastructs.NewEndpointData()
 		So(data.NamesSentToSuggest, ShouldNotBeNil)
+		Convey("ForScottyTest tag set", func() {
+			app := &datastructs.ApplicationStatus{
+				Aws: &mdb.AwsMetadata{
+					AccountId:  "2468",
+					InstanceId: "1357",
+					Tags: map[string]string{
+						"ForScottyTest":           "true",
+						"PushMetricsToCloudWatch": "",
+					},
+				},
+			}
+			Convey("Machines with ForScottyTest tag applicable for test scotty with CloudHealth", func() {
+				newData := data.UpdateForCloudHealth(app, nil, true)
+				So(newData, ShouldNotEqual, data)
+			})
+			Convey("Machines with ForScottyTest tag applicable for test scotty with CloudWatch", func() {
+				newData := data.UpdateForCloudWatch(app, 5*time.Minute, true)
+				So(newData, ShouldNotEqual, data)
+			})
+			Convey("Machines with ForScottyTest tag not applicable for production scotty with cloud health", func() {
+				newData := data.UpdateForCloudHealth(app, nil, false)
+				So(newData, ShouldEqual, data)
+			})
+			Convey("Machines with ForScottyTest tag not applicable for production scotty with cloud watch", func() {
+				newData := data.UpdateForCloudWatch(app, 5*time.Minute, false)
+				So(newData, ShouldEqual, data)
+			})
+		})
 		Convey("With accountId and instanceId", func() {
 			app := &datastructs.ApplicationStatus{
 				Aws: &mdb.AwsMetadata{
@@ -19,34 +47,37 @@ func TestEndpointData(t *testing.T) {
 					InstanceId: "1357",
 				},
 			}
+
+			Convey("CloudHealth not applicable for test scotty", func() {
+				newData := data.UpdateForCloudHealth(app, nil, true)
+				So(newData, ShouldEqual, data)
+			})
+
 			Convey("CloudHealth should work", func() {
-				newData := data.UpdateForCloudHealth(app, nil)
+				newData := data.UpdateForCloudHealth(app, nil, false)
 				So(newData, ShouldNotEqual, data)
 				So(newData.CHRollup.InstanceId(), ShouldEqual, "1357")
 				So(newData.CHRollup.AccountNumber(), ShouldEqual, "2468")
 				So(newData.CHCombineFS, ShouldBeTrue)
 
 				Convey("No new memory allocation if nothing changed", func() {
-					newData2 := newData.UpdateForCloudHealth(app, nil)
+					newData2 := newData.UpdateForCloudHealth(app, nil, false)
 					So(newData2, ShouldEqual, newData)
 				})
 			})
 			Convey("CloudHealth shouldn't combine fs if turned off.", func() {
 				newData := data.UpdateForCloudHealth(
-					app,
-					map[string]bool{})
+					app, map[string]bool{}, false)
 				So(newData.CHCombineFS, ShouldBeFalse)
 			})
 			Convey("CloudHealth shouldn't combine fs if instanceId doesn't match.", func() {
 				newData := data.UpdateForCloudHealth(
-					app,
-					map[string]bool{"9999": true})
+					app, map[string]bool{"9999": true}, false)
 				So(newData.CHCombineFS, ShouldBeFalse)
 			})
 			Convey("CloudHealth should combine fs if instanceId matches.", func() {
 				newData := data.UpdateForCloudHealth(
-					app,
-					map[string]bool{"1357": true})
+					app, map[string]bool{"1357": true}, false)
 				So(newData.CHCombineFS, ShouldBeTrue)
 			})
 		})
@@ -60,13 +91,19 @@ func TestEndpointData(t *testing.T) {
 					},
 				},
 			}
-			newData := data.UpdateForCloudWatch(app, 5*time.Minute)
+			// Scotty for testing ignores this machine for cloudwatch
+			So(
+				data.UpdateForCloudWatch(app, 5*time.Minute, true),
+				ShouldEqual,
+				data)
+			newData := data.UpdateForCloudWatch(app, 5*time.Minute, false)
 			So(newData, ShouldNotEqual, data)
 			So(newData.CWRollup.InstanceId(), ShouldEqual, "1357")
 			So(newData.CWRollup.AccountNumber(), ShouldEqual, "2468")
 			So(newData.CWRollup.RoundDuration(), ShouldEqual, 2*time.Minute)
 			Convey("No new memory allocation if nothing changed", func() {
-				noChange := newData.UpdateForCloudWatch(app, 5*time.Minute)
+				noChange := newData.UpdateForCloudWatch(
+					app, 5*time.Minute, false)
 				So(noChange, ShouldEqual, newData)
 			})
 			Convey("CloudWatch should accept changes", func() {
@@ -78,7 +115,8 @@ func TestEndpointData(t *testing.T) {
 							InstanceId: "1357",
 						},
 					}
-					newData := data.UpdateForCloudWatch(app, 5*time.Minute)
+					newData := data.UpdateForCloudWatch(
+						app, 5*time.Minute, false)
 					So(newData, ShouldNotEqual, data)
 					So(newData.CWRollup, ShouldBeNil)
 				})
@@ -92,7 +130,8 @@ func TestEndpointData(t *testing.T) {
 							},
 						},
 					}
-					newData := data.UpdateForCloudWatch(app, 5*time.Minute)
+					newData := data.UpdateForCloudWatch(
+						app, 5*time.Minute, false)
 					So(newData, ShouldNotEqual, data)
 					So(newData.CWRollup.InstanceId(), ShouldEqual, "1357")
 					So(newData.CWRollup.AccountNumber(), ShouldEqual, "2468")
@@ -108,7 +147,8 @@ func TestEndpointData(t *testing.T) {
 							},
 						},
 					}
-					newData := data.UpdateForCloudWatch(app, 5*time.Minute)
+					newData := data.UpdateForCloudWatch(
+						app, 5*time.Minute, false)
 					So(newData, ShouldNotEqual, data)
 					So(newData.CWRollup.InstanceId(), ShouldEqual, "1357")
 					So(newData.CWRollup.AccountNumber(), ShouldEqual, "2468")


### PR DESCRIPTION
If the ForScottyTest AWS tag is set, production scotty ignores that
machine when writing metrics to cloudhealth and cloudwatch. But the
testing instance of scotty (flag --testInstance in scotty command line
args) ignores machines that DO NOT have the ForScottyTest AWS tag set.