### PR TITLE
Introduce "CloudHealthTest" and "CloudWatchTest" AWS tag.

### DIFF
--- a/apps/scotty/collect.go
+++ b/apps/scotty/collect.go
@@ -57,6 +57,10 @@ var (
 		"cloudWatchFreq",
 		5*time.Minute,
 		"Rollup time for cloudwatch")
+	fCloudHealthTest = flag.Bool(
+		"cloudHealthTest", false, "Whether or not this is testing cloudhealth")
+	fCloudWatchTest = flag.Bool(
+		"cloudWatchTest", false, "Whether or not this is testing cloudwatch")
 )
 
 func init() {
@@ -444,11 +448,11 @@ func startCollector(
 				if endpoint.Port() == 6910 {
 					if cloudHealthChannel != nil {
 						endpointData = endpointData.UpdateForCloudHealth(
-							app, combineFsMap)
+							app, combineFsMap, *fCloudHealthTest)
 					}
 					if cloudWatchChannel != nil {
 						endpointData = endpointData.UpdateForCloudWatch(
-							app, *fCloudWatchFreq)
+							app, *fCloudWatchFreq, *fCloudWatchTest)
 					}
 				}
 				endpointToData[endpoint] = endpointData

--- a/datastructs/api.go
+++ b/datastructs/api.go
@@ -125,13 +125,13 @@ func (a *ApplicationStatus) InstanceId() string {
 // CloudHealthTest returns true iff the machine of this endpoint is for testing
 // scotty with cloud health
 func (a *ApplicationStatus) CloudHealthTest() bool {
-	return a.forTest("CloudHealthTest")
+	return a.forTest("ScottyCloudHealthTest")
 }
 
 // CloudWatchTest returns true iff the machine of this endpoint is for testing
 // scotty with cloud watch
 func (a *ApplicationStatus) CloudWatchTest() bool {
-	return a.forTest("CloudWatchTest")
+	return a.forTest("ScottyCloudWatchTest")
 }
 
 // CloudWatch returns how often data for the machine gets written to

--- a/datastructs/api.go
+++ b/datastructs/api.go
@@ -47,12 +47,15 @@ func NewEndpointData() *EndpointData {
 // collect cloud health data. app represents the endpoint; combineFsMap
 // is a map of instance ids for which file system metrics should be rolled up.
 // A nil map means file system metrics should be rolled up for all instance Ids.
-// An empty map means file system metrics should never be rolled up.
+// An empty map means file system metrics should never be rolled up. bTestRun
+// is true if this is a test instance of scotty.
 //
 // If nothing changed, UpdateForCloudHealth just returns e.
 func (e *EndpointData) UpdateForCloudHealth(
-	app *ApplicationStatus, combineFsMap map[string]bool) *EndpointData {
-	return e.updateForCloudHealth(app, combineFsMap)
+	app *ApplicationStatus,
+	combineFsMap map[string]bool,
+	bTestRun bool) *EndpointData {
+	return e.updateForCloudHealth(app, combineFsMap, bTestRun)
 }
 
 // UpdateForCloudWatch returns a new EndpointData instance set up to collect
@@ -65,9 +68,12 @@ func (e *EndpointData) UpdateForCloudHealth(
 // the time in there is the roll up time to use. If the tag exists but the
 // value is missing, that means use defaultFreq for the rollup time. If
 // the tag doesn't exist, that means don't collect data for cloud watch.
+// bTestRun is true if this is a test instance of scotty.
 func (e *EndpointData) UpdateForCloudWatch(
-	app *ApplicationStatus, defaultFreq time.Duration) *EndpointData {
-	return e.updateForCloudWatch(app, defaultFreq)
+	app *ApplicationStatus,
+	defaultFreq time.Duration,
+	bTestRun bool) *EndpointData {
+	return e.updateForCloudWatch(app, defaultFreq, bTestRun)
 }
 
 // ApplicationStatus represents the status of a single application.
@@ -114,6 +120,18 @@ func (a *ApplicationStatus) AccountNumber() string {
 // or the empty string if machine is not an AWS machine.
 func (a *ApplicationStatus) InstanceId() string {
 	return a.instanceId()
+}
+
+// CloudHealthTest returns true iff the machine of this endpoint is for testing
+// scotty with cloud health
+func (a *ApplicationStatus) CloudHealthTest() bool {
+	return a.forTest("CloudHealthTest")
+}
+
+// CloudWatchTest returns true iff the machine of this endpoint is for testing
+// scotty with cloud watch
+func (a *ApplicationStatus) CloudWatchTest() bool {
+	return a.forTest("CloudWatchTest")
 }
 
 // CloudWatch returns how often data for the machine gets written to

--- a/datastructs/datastructs.go
+++ b/datastructs/datastructs.go
@@ -96,6 +96,14 @@ func parseDuration(durStr string) (time.Duration, error) {
 	return dur, nil
 }
 
+func (a *ApplicationStatus) forTest(tagName string) bool {
+	if a.Aws != nil {
+		_, ok := a.Aws.Tags[tagName]
+		return ok
+	}
+	return false
+}
+
 func (a *ApplicationStatus) cloudWatch() string {
 	if a.Aws != nil {
 		if result, ok := a.Aws.Tags[kCloudWatchTag]; ok {

--- a/datastructs/endpointdata_test.go
+++ b/datastructs/endpointdata_test.go
@@ -12,31 +12,31 @@ func TestEndpointData(t *testing.T) {
 	Convey("With EndpointData", t, func() {
 		data := datastructs.NewEndpointData()
 		So(data.NamesSentToSuggest, ShouldNotBeNil)
-		Convey("CloudWatchTest and CloudHealthTest tags set", func() {
+		Convey("ScottyCloudWatchTest and ScottyCloudHealthTest tags set", func() {
 			app := &datastructs.ApplicationStatus{
 				Aws: &mdb.AwsMetadata{
 					AccountId:  "2468",
 					InstanceId: "1357",
 					Tags: map[string]string{
-						"CloudWatchTest":          "true",
-						"CloudHealthTest":         "true",
+						"ScottyCloudWatchTest":    "true",
+						"ScottyCloudHealthTest":   "true",
 						"PushMetricsToCloudWatch": "",
 					},
 				},
 			}
-			Convey("Machines with CloudHealthTest tag applicable for test scotty with CloudHealth", func() {
+			Convey("Machines with ScottyCloudHealthTest tag applicable for test scotty with CloudHealth", func() {
 				newData := data.UpdateForCloudHealth(app, nil, true)
 				So(newData, ShouldNotEqual, data)
 			})
-			Convey("Machines with CloudWatchTest tag applicable for test scotty with CloudWatch", func() {
+			Convey("Machines with ScottyCloudWatchTest tag applicable for test scotty with CloudWatch", func() {
 				newData := data.UpdateForCloudWatch(app, 5*time.Minute, true)
 				So(newData, ShouldNotEqual, data)
 			})
-			Convey("Machines with CloudHealthTest tag not applicable for production scotty with cloud health", func() {
+			Convey("Machines with ScottyCloudHealthTest tag not applicable for production scotty with cloud health", func() {
 				newData := data.UpdateForCloudHealth(app, nil, false)
 				So(newData, ShouldEqual, data)
 			})
-			Convey("Machines with CloudWatchTest tag not applicable for production scotty with cloud watch", func() {
+			Convey("Machines with ScottyCloudWatchTest tag not applicable for production scotty with cloud watch", func() {
 				newData := data.UpdateForCloudWatch(app, 5*time.Minute, false)
 				So(newData, ShouldEqual, data)
 			})

--- a/datastructs/endpointdata_test.go
+++ b/datastructs/endpointdata_test.go
@@ -12,6 +12,35 @@ func TestEndpointData(t *testing.T) {
 	Convey("With EndpointData", t, func() {
 		data := datastructs.NewEndpointData()
 		So(data.NamesSentToSuggest, ShouldNotBeNil)
+		Convey("CloudWatchTest and CloudHealthTest tags set", func() {
+			app := &datastructs.ApplicationStatus{
+				Aws: &mdb.AwsMetadata{
+					AccountId:  "2468",
+					InstanceId: "1357",
+					Tags: map[string]string{
+						"CloudWatchTest":          "true",
+						"CloudHealthTest":         "true",
+						"PushMetricsToCloudWatch": "",
+					},
+				},
+			}
+			Convey("Machines with CloudHealthTest tag applicable for test scotty with CloudHealth", func() {
+				newData := data.UpdateForCloudHealth(app, nil, true)
+				So(newData, ShouldNotEqual, data)
+			})
+			Convey("Machines with CloudWatchTest tag applicable for test scotty with CloudWatch", func() {
+				newData := data.UpdateForCloudWatch(app, 5*time.Minute, true)
+				So(newData, ShouldNotEqual, data)
+			})
+			Convey("Machines with CloudHealthTest tag not applicable for production scotty with cloud health", func() {
+				newData := data.UpdateForCloudHealth(app, nil, false)
+				So(newData, ShouldEqual, data)
+			})
+			Convey("Machines with CloudWatchTest tag not applicable for production scotty with cloud watch", func() {
+				newData := data.UpdateForCloudWatch(app, 5*time.Minute, false)
+				So(newData, ShouldEqual, data)
+			})
+		})
 		Convey("With accountId and instanceId", func() {
 			app := &datastructs.ApplicationStatus{
 				Aws: &mdb.AwsMetadata{
@@ -19,34 +48,37 @@ func TestEndpointData(t *testing.T) {
 					InstanceId: "1357",
 				},
 			}
+
+			Convey("CloudHealth not applicable for test scotty", func() {
+				newData := data.UpdateForCloudHealth(app, nil, true)
+				So(newData, ShouldEqual, data)
+			})
+
 			Convey("CloudHealth should work", func() {
-				newData := data.UpdateForCloudHealth(app, nil)
+				newData := data.UpdateForCloudHealth(app, nil, false)
 				So(newData, ShouldNotEqual, data)
 				So(newData.CHRollup.InstanceId(), ShouldEqual, "1357")
 				So(newData.CHRollup.AccountNumber(), ShouldEqual, "2468")
 				So(newData.CHCombineFS, ShouldBeTrue)
 
 				Convey("No new memory allocation if nothing changed", func() {
-					newData2 := newData.UpdateForCloudHealth(app, nil)
+					newData2 := newData.UpdateForCloudHealth(app, nil, false)
 					So(newData2, ShouldEqual, newData)
 				})
 			})
 			Convey("CloudHealth shouldn't combine fs if turned off.", func() {
 				newData := data.UpdateForCloudHealth(
-					app,
-					map[string]bool{})
+					app, map[string]bool{}, false)
 				So(newData.CHCombineFS, ShouldBeFalse)
 			})
 			Convey("CloudHealth shouldn't combine fs if instanceId doesn't match.", func() {
 				newData := data.UpdateForCloudHealth(
-					app,
-					map[string]bool{"9999": true})
+					app, map[string]bool{"9999": true}, false)
 				So(newData.CHCombineFS, ShouldBeFalse)
 			})
 			Convey("CloudHealth should combine fs if instanceId matches.", func() {
 				newData := data.UpdateForCloudHealth(
-					app,
-					map[string]bool{"1357": true})
+					app, map[string]bool{"1357": true}, false)
 				So(newData.CHCombineFS, ShouldBeTrue)
 			})
 		})
@@ -60,13 +92,19 @@ func TestEndpointData(t *testing.T) {
 					},
 				},
 			}
-			newData := data.UpdateForCloudWatch(app, 5*time.Minute)
+			// Scotty for testing ignores this machine for cloudwatch
+			So(
+				data.UpdateForCloudWatch(app, 5*time.Minute, true),
+				ShouldEqual,
+				data)
+			newData := data.UpdateForCloudWatch(app, 5*time.Minute, false)
 			So(newData, ShouldNotEqual, data)
 			So(newData.CWRollup.InstanceId(), ShouldEqual, "1357")
 			So(newData.CWRollup.AccountNumber(), ShouldEqual, "2468")
 			So(newData.CWRollup.RoundDuration(), ShouldEqual, 2*time.Minute)
 			Convey("No new memory allocation if nothing changed", func() {
-				noChange := newData.UpdateForCloudWatch(app, 5*time.Minute)
+				noChange := newData.UpdateForCloudWatch(
+					app, 5*time.Minute, false)
 				So(noChange, ShouldEqual, newData)
 			})
 			Convey("CloudWatch should accept changes", func() {
@@ -78,7 +116,8 @@ func TestEndpointData(t *testing.T) {
 							InstanceId: "1357",
 						},
 					}
-					newData := data.UpdateForCloudWatch(app, 5*time.Minute)
+					newData := data.UpdateForCloudWatch(
+						app, 5*time.Minute, false)
 					So(newData, ShouldNotEqual, data)
 					So(newData.CWRollup, ShouldBeNil)
 				})
@@ -92,7 +131,8 @@ func TestEndpointData(t *testing.T) {
 							},
 						},
 					}
-					newData := data.UpdateForCloudWatch(app, 5*time.Minute)
+					newData := data.UpdateForCloudWatch(
+						app, 5*time.Minute, false)
 					So(newData, ShouldNotEqual, data)
 					So(newData.CWRollup.InstanceId(), ShouldEqual, "1357")
 					So(newData.CWRollup.AccountNumber(), ShouldEqual, "2468")
@@ -108,7 +148,8 @@ func TestEndpointData(t *testing.T) {
 							},
 						},
 					}
-					newData := data.UpdateForCloudWatch(app, 5*time.Minute)
+					newData := data.UpdateForCloudWatch(
+						app, 5*time.Minute, false)
 					So(newData, ShouldNotEqual, data)
 					So(newData.CWRollup.InstanceId(), ShouldEqual, "1357")
 					So(newData.CWRollup.AccountNumber(), ShouldEqual, "2468")


### PR DESCRIPTION
If the ForScottyTest AWS tag is set, production scotty ignores that
machine when writing metrics to cloudhealth and cloudwatch. But the
testing instance of scotty (flag --testInstance in scotty command line
args) ignores machines that DO NOT have the ForScottyTest AWS tag set.