### PR TITLE
Introduce store.TypeFilterer.

### DIFF
--- a/pstore/api.go
+++ b/pstore/api.go
@@ -302,7 +302,7 @@ func (c *ConsumerMetrics) ValuesNotWritten() uint64 {
 // ConsumerMetricStore instances are safe to use with multiple goroutines.
 type ConsumerMetricsStore struct {
 	w                  *RecordWriterWithMetrics
-	filterer           store.Filterer
+	filterer           store.TypeFilterer
 	lock               sync.Mutex
 	recordCount        uint64
 	removedRecordCount uint64
@@ -451,6 +451,7 @@ type ConsumerWithMetricsBuilder struct {
 	c       *ConsumerWithMetrics
 	hooks   []RecordWriteHooker
 	metrics ConsumerMetrics
+	filter  func(*store.MetricInfo) bool
 	paused  bool
 }
 

--- a/store/api.go
+++ b/store/api.go
@@ -223,6 +223,37 @@ type Filterer interface {
 	Filter(*Record) bool
 }
 
+// TypeFilterer filters by metric type. Using filters that implement this
+// interface provide for special optimisations. For intance, using filters of
+// this type allow skipping and entire time series rather than visiting a
+// time series while filtering out every value in. Using these filters allows
+// scotty to traverse values not written to persistent storage up to 5X
+// faster.
+type TypeFilterer interface {
+	// If FilterByType returns false then Filter should return false for
+	// any value from that metric for consistency. However, if FilterByType
+	// returns true, the Filter method may stil return false.
+	Filterer
+	// FilterByType returns true if values of a given metric should
+	// be included.
+	FilterByType(info *MetricInfo) bool
+}
+
+// TypeFilterFuncActiveOnly converts a function filtering by metric type
+// into a TypeFilterer.
+type TypeFiltererFuncActiveOnly func(*MetricInfo) bool
+
+// FilterByType returns true if and only if f returns true.
+func (f TypeFiltererFuncActiveOnly) FilterByType(m *MetricInfo) bool {
+	return f(m)
+}
+
+// Filter returns true if and only if f returns true for the metric type
+// and the metric value is flagged as active.
+func (f TypeFiltererFuncActiveOnly) Filter(r *Record) bool {
+	return f(r.Info) && r.Active
+}
+
 // FiltererFunc is an adapter allowing an ordinary function to be used as a
 // Filterer.
 type FiltererFunc func(*Record) bool
@@ -332,11 +363,11 @@ func NamedIteratorFilterFunc(
 
 // NamedIteratorFilter returns an Iterator like the given one except
 // that it yields only metric values for which filter returns true.
+// If filter is a TypeFilterer, the returned NamedIterator will apply
+// opitimisations if possible.
 func NamedIteratorFilter(
 	ni NamedIterator, filter Filterer) NamedIterator {
-	return &changedNamedIteratorType{
-		NamedIterator: ni,
-		change:        IteratorFilter(ni, filter)}
+	return namedIteratorFilter(ni, filter)
 }
 
 // NamedIteratorCoordinate returns an Iterator like given one except that


### PR DESCRIPTION
Using filters of this type instead of ordinary filters can allow scotty
to traverse values not written to persistent storage up to 5X faster.