### PR TITLE
Add writePositionIndex metric.

### DIFF
--- a/store/api.go
+++ b/store/api.go
@@ -674,6 +674,24 @@ func (s *Store) TsdbTimeSeries(
 	return s.tsdbTimeSeries(name, endpointId, start, end)
 }
 
+// FloatVar represents a floating point random variable
+type FloatVar struct {
+	Sum   float64
+	Count uint64
+}
+
+// Avg computes the average of this random variable. Returns NaN if this
+// instance is empty (Count == 0).
+func (f FloatVar) Avg() float64 {
+	return f.Sum / float64(f.Count)
+}
+
+// Add adds the values in a to this random variable
+func (f *FloatVar) Add(a FloatVar) {
+	f.Sum += a.Sum
+	f.Count += a.Count
+}
+
 // NamedIteratorForEndpoint returns an iterator for the given name that
 // iterates over metric values for all known timestamps for the given endpoint.
 // Since the name is used to track progress of iterating over the given
@@ -702,7 +720,7 @@ func (s *Store) NamedIteratorForEndpoint(
 	name string,
 	endpointId interface{},
 	maxFrames uint) (
-	iterator NamedIterator, remainingValuesInSeconds float64) {
+	iterator NamedIterator, remainingValuesInSeconds float64, percentCaughtUp FloatVar) {
 	return s.namedIteratorForEndpoint(name, endpointId, int(maxFrames))
 }
 
@@ -760,7 +778,7 @@ func (s *Store) NamedIteratorForEndpointRollUp(
 	dur time.Duration,
 	maxFrames uint,
 	strategy MetricGroupingStrategy) (
-	iterator NamedIterator, remainingValuesInSeconds float64) {
+	iterator NamedIterator, remainingValuesInSeconds float64, percentCaughtUp FloatVar) {
 	return s.namedIteratorForEndpointRollUp(
 		name, endpointId, dur, int(maxFrames), strategy)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -95,7 +95,7 @@ func (s *Store) byPrefixAndEndpoint(
 func (s *Store) namedIteratorForEndpoint(
 	name string,
 	endpointId interface{},
-	maxFrames int) (NamedIterator, float64) {
+	maxFrames int) (NamedIterator, float64, FloatVar) {
 	return s.byApplication[endpointId].NewNamedIterator(
 		name, maxFrames, GroupMetricByPathAndNumeric)
 }
@@ -105,7 +105,7 @@ func (s *Store) namedIteratorForEndpointRollUp(
 	endpointId interface{},
 	duration time.Duration,
 	maxFrames int,
-	strategy MetricGroupingStrategy) (NamedIterator, float64) {
+	strategy MetricGroupingStrategy) (NamedIterator, float64, FloatVar) {
 	return s.byApplication[endpointId].NewNamedIteratorRollUp(
 		name,
 		float64(duration)/float64(time.Second),

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -663,14 +663,14 @@ func TestIteratorPageEviction(t *testing.T) {
 		aMetric[1].Value = int64(2*(ts/20) + 1)
 		aStore.AddBatch(kEndpoint0, float64(ts), aMetric[:].Sorted())
 	}
-	iterator, _ := aStore.NamedIteratorForEndpoint(
+	iterator, _, _ := aStore.NamedIteratorForEndpoint(
 		"anIterator", kEndpoint0, 0)
 	consumer.Iterate(t, iterator)
 	assertValueEquals(t, 20, consumer.Count)
 
 	iterator.Commit()
 
-	iterator, _ = aStore.NamedIteratorForEndpoint(
+	iterator, _, _ = aStore.NamedIteratorForEndpoint(
 		"anIterator", kEndpoint0, 0)
 	consumer.Iterate(t, iterator)
 	assertValueEquals(t, 0, consumer.Count)
@@ -681,7 +681,7 @@ func TestIteratorPageEviction(t *testing.T) {
 		aStore.AddBatch(kEndpoint0, float64(ts), aMetric[:].Sorted())
 	}
 
-	iterator, _ = aStore.NamedIteratorForEndpoint(
+	iterator, _, _ = aStore.NamedIteratorForEndpoint(
 		"anIterator", kEndpoint0, 5)
 	consumer.Iterate(t, iterator)
 	// 2 time series * max 5 value, timestamp pairs each
@@ -697,7 +697,7 @@ func TestIteratorPageEviction(t *testing.T) {
 		aMetric[1].Value = int64(2*(ts/20) + 1)
 		aStore.AddBatch(kEndpoint0, float64(ts), aMetric[:].Sorted())
 	}
-	iterator, _ = aStore.NamedIteratorForEndpoint(
+	iterator, _, _ = aStore.NamedIteratorForEndpoint(
 		"anIterator", kEndpoint0, 0)
 	consumer.Iterate(t, iterator)
 	if consumer.MinTimeStamp < 360.0 { // max 14 timestamps
@@ -714,7 +714,7 @@ func TestIteratorPageEviction(t *testing.T) {
 	// Now remove all pages. This should actually remove all pages save 1.
 	aStore.LessenPageCount(1.0)
 
-	anotherIterator, _ := aStore.NamedIteratorForEndpoint(
+	anotherIterator, _, _ := aStore.NamedIteratorForEndpoint(
 		"anotherIterator", kEndpoint0, 0)
 	var anotherConsumer iteratorPageEvictionTestType
 	anotherConsumer.Iterate(t, anotherIterator)
@@ -836,7 +836,7 @@ func TestRollUpIterator(t *testing.T) {
 
 	beginning := expected.Checkpoint()
 
-	iterator, timeAfterIterator := aStore.NamedIteratorForEndpointRollUp(
+	iterator, timeAfterIterator, _ := aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
 		kEndpoint0,
 		2*time.Minute,
@@ -856,7 +856,7 @@ func TestRollUpIterator(t *testing.T) {
 	expected.Restore(beginning)
 
 	// max 3 times per metric
-	iterator, _ = aStore.NamedIteratorForEndpointRollUp(
+	iterator, _, _ = aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
 		kEndpoint0,
 		2*time.Minute,
@@ -864,7 +864,7 @@ func TestRollUpIterator(t *testing.T) {
 		store.GroupMetricByPathAndNumeric)
 	expected.Iterate(t, iterator)
 	expected.Restore(beginning)
-	iterator, timeAfterIterator = aStore.NamedIteratorForEndpointRollUp(
+	iterator, timeAfterIterator, _ = aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
 		kEndpoint0,
 		2*time.Minute,
@@ -875,7 +875,7 @@ func TestRollUpIterator(t *testing.T) {
 	iterator.Commit()
 
 	checkpoint := expected.Checkpoint()
-	iterator, _ = aStore.NamedIteratorForEndpointRollUp(
+	iterator, _, _ = aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
 		kEndpoint0,
 		2*time.Minute,
@@ -883,7 +883,7 @@ func TestRollUpIterator(t *testing.T) {
 		store.GroupMetricByPathAndNumeric)
 	expected.Iterate(t, iterator)
 	expected.Restore(checkpoint)
-	iterator, timeAfterIterator = aStore.NamedIteratorForEndpointRollUp(
+	iterator, timeAfterIterator, _ = aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
 		kEndpoint0,
 		2*time.Minute,
@@ -895,7 +895,7 @@ func TestRollUpIterator(t *testing.T) {
 
 	expected.VerifyDone(t)
 
-	iterator, timeAfterIterator = aStore.NamedIteratorForEndpointRollUp(
+	iterator, timeAfterIterator, _ = aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
 		kEndpoint0,
 		2*time.Minute,
@@ -910,7 +910,7 @@ func TestRollUpIterator(t *testing.T) {
 	// and creating a new iterator. Since we committed the previous
 	// iterator, we have to use a new name to start from the beginning.
 	expected.Restore(beginning)
-	iterator, _ = aStore.NamedIteratorForEndpointRollUp(
+	iterator, _, _ = aStore.NamedIteratorForEndpointRollUp(
 		"anotherIterator",
 		kEndpoint0,
 		2*time.Minute,
@@ -920,7 +920,7 @@ func TestRollUpIterator(t *testing.T) {
 		t, iteratorLimit(iterator, 8)))
 	iterator.Commit()
 
-	iterator, _ = aStore.NamedIteratorForEndpointRollUp(
+	iterator, _, _ = aStore.NamedIteratorForEndpointRollUp(
 		"anotherIterator",
 		kEndpoint0,
 		2*time.Minute,
@@ -969,7 +969,7 @@ func TestRollUpIterator(t *testing.T) {
 	expected.Add("String", 96600.0, "far")
 	expected.Add("Inactive", 120480.0, 8.3)
 
-	iterator, _ = aStore.NamedIteratorForEndpointRollUp(
+	iterator, _, _ = aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
 		kEndpoint0,
 		2*time.Minute,
@@ -987,7 +987,7 @@ func TestRollUpIterator(t *testing.T) {
 		expected.Add("Float", 96480.0, 3.1875)
 
 		// beginning := expected.Checkpoint()
-		iterator, _ := aStore.NamedIteratorForEndpointRollUp(
+		iterator, _, _ := aStore.NamedIteratorForEndpointRollUp(
 			"filtered",
 			kEndpoint0,
 			2*time.Minute,
@@ -1001,7 +1001,7 @@ func TestRollUpIterator(t *testing.T) {
 		expected.Iterate(t, iterator)
 		iterator.Commit()
 
-		iterator, _ = aStore.NamedIteratorForEndpointRollUp(
+		iterator, _, _ = aStore.NamedIteratorForEndpointRollUp(
 			"filtered",
 			kEndpoint0,
 			2*time.Minute,
@@ -1049,7 +1049,7 @@ func TestRollUpIteratorBool(t *testing.T) {
 	expected.Add("path", 30300.0, false)
 	expected.Add("path", 30900.0, true)
 
-	iterator, _ := aStore.NamedIteratorForEndpointRollUp(
+	iterator, _, _ := aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
 		kEndpoint0,
 		5*time.Minute,
@@ -1090,7 +1090,7 @@ func TestRollUpIteratorInt8(t *testing.T) {
 	expected.Add("path", 30300.0, int8(-128))
 	expected.Add("path", 30900.0, int8(127))
 
-	iterator, _ := aStore.NamedIteratorForEndpointRollUp(
+	iterator, _, _ := aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
 		kEndpoint0,
 		5*time.Minute,
@@ -1135,7 +1135,7 @@ func TestIteratorSamePathDifferentTypeRollUp(t *testing.T) {
 	expected.Add("foo", 1260.0, float64(1830.0))
 	expected.Add("foo", 1320.0, "hello")
 
-	iterator, _ := aStore.NamedIteratorForEndpointRollUp(
+	iterator, _, _ := aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
 		kEndpoint0,
 		60*time.Second,
@@ -1183,7 +1183,7 @@ func TestIteratorSamePathDifferentType(t *testing.T) {
 	expected.Add("foo", 1030.0, int64(30))
 	expected.Add("bar", 1030.0, int16(31))
 
-	iterator, _ := aStore.NamedIteratorForEndpoint(
+	iterator, _, _ := aStore.NamedIteratorForEndpoint(
 		"anIterator", kEndpoint0, 0)
 	expected.Iterate(t, iterator)
 	expected.VerifyDone(t)
@@ -1430,7 +1430,7 @@ func TestIterator(t *testing.T) {
 
 	beginning := expected.Checkpoint()
 
-	iterator, timeAfterIterator := aStore.NamedIteratorForEndpoint(
+	iterator, timeAfterIterator, _ := aStore.NamedIteratorForEndpoint(
 		"anIterator", kEndpoint0, 0)
 	assertValueEquals(t, 0.0, timeAfterIterator)
 
@@ -1447,12 +1447,12 @@ func TestIterator(t *testing.T) {
 	expected.Restore(beginning)
 
 	// max 2 times per metric
-	iterator, timeAfterIterator = aStore.NamedIteratorForEndpoint(
+	iterator, timeAfterIterator, _ = aStore.NamedIteratorForEndpoint(
 		"anIterator", kEndpoint0, 2)
 	assertValueEquals(t, 800.001, timeAfterIterator)
 	expected.Iterate(t, iterator)
 	expected.Restore(beginning)
-	iterator, _ = aStore.NamedIteratorForEndpoint(
+	iterator, _, _ = aStore.NamedIteratorForEndpoint(
 		"anIterator", kEndpoint0, 2)
 	valueCount := expected.Iterate(t, iterator)
 	iterator.Commit()
@@ -1461,19 +1461,19 @@ func TestIterator(t *testing.T) {
 		if valueCount > 8 {
 			t.Error("Got too many values")
 		}
-		iterator, _ = aStore.NamedIteratorForEndpoint(
+		iterator, _, _ = aStore.NamedIteratorForEndpoint(
 			"anIterator", kEndpoint0, 2)
 		checkpoint := expected.Checkpoint()
 		expected.Iterate(t, iterator)
 		expected.Restore(checkpoint)
-		iterator, _ = aStore.NamedIteratorForEndpoint(
+		iterator, _, _ = aStore.NamedIteratorForEndpoint(
 			"anIterator", kEndpoint0, 2)
 		valueCount = expected.Iterate(t, iterator)
 		iterator.Commit()
 	}
 	expected.VerifyDone(t)
 
-	iterator, timeAfterIterator = aStore.NamedIteratorForEndpoint(
+	iterator, timeAfterIterator, _ = aStore.NamedIteratorForEndpoint(
 		"anIterator", kEndpoint0, 2)
 	assertValueEquals(t, 0.0, timeAfterIterator)
 	expected.Iterate(t, iterator)
@@ -1485,12 +1485,12 @@ func TestIterator(t *testing.T) {
 	// iterator, we have to use a new name to start from the beginning.
 	expected.Restore(beginning)
 
-	iterator, _ = aStore.NamedIteratorForEndpoint(
+	iterator, _, _ = aStore.NamedIteratorForEndpoint(
 		"anotherIterator", kEndpoint0, 0)
 	valueCount = expected.Iterate(t, iteratorLimit(iterator, 5))
 	iterator.Commit()
 	for valueCount > 0 {
-		iterator, _ = aStore.NamedIteratorForEndpoint(
+		iterator, _, _ = aStore.NamedIteratorForEndpoint(
 			"anotherIterator", kEndpoint0, 0)
 		newValueCount := expected.Iterate(t, iteratorLimit(iterator, 5))
 		if !(valueCount == 5 || (valueCount < 5 && newValueCount == 0)) {
@@ -1507,7 +1507,7 @@ func TestIterator(t *testing.T) {
 	filteredExpected.Add("Alice", 200.0, int64(0))
 	filteredExpected.Add("Alice", 300.0, int64(200))
 
-	iterator, _ = aStore.NamedIteratorForEndpoint(
+	iterator, _, _ = aStore.NamedIteratorForEndpoint(
 		"aThirdIterator", kEndpoint0, 0)
 	filteredIterator := store.NamedIteratorFilterFunc(
 		iterator,
@@ -1518,7 +1518,7 @@ func TestIterator(t *testing.T) {
 	filteredExpected.VerifyDone(t)
 	filteredIterator.Commit()
 
-	iterator, _ = aStore.NamedIteratorForEndpoint(
+	iterator, _, _ = aStore.NamedIteratorForEndpoint(
 		"aThirdIterator", kEndpoint0, 0)
 	filteredExpected.Iterate(t, iterator)
 
@@ -1535,7 +1535,7 @@ func TestIterator(t *testing.T) {
 		expected.Add("Alice", 800.0, int64(700))
 		expected.Add("Alice", 1000.0, int64(900))
 
-		iterator, _ := aStore.NamedIteratorForEndpoint(
+		iterator, _, _ := aStore.NamedIteratorForEndpoint(
 			"aFilteredIterator", kEndpoint0, 0)
 		iterator = store.NamedIteratorFilter(iterator,
 			store.TypeFiltererFuncActiveOnly(
@@ -1547,11 +1547,11 @@ func TestIterator(t *testing.T) {
 	}
 
 	// Test StartAtBeginning
-	toStartAtBeginningIterator0, _ := aStore.NamedIteratorForEndpoint(
+	toStartAtBeginningIterator0, _, _ := aStore.NamedIteratorForEndpoint(
 		"toStartAtBeginning0", kEndpoint0, 0)
-	toStartAtBeginningIterator1, _ := aStore.NamedIteratorForEndpoint(
+	toStartAtBeginningIterator1, _, _ := aStore.NamedIteratorForEndpoint(
 		"toStartAtBeginning1", kEndpoint0, 0)
-	toStartAtBeginningIterator2, _ := aStore.NamedIteratorForEndpoint(
+	toStartAtBeginningIterator2, _, _ := aStore.NamedIteratorForEndpoint(
 		"toStartAtBeginning2", kEndpoint0, 0)
 	count0 := countItems(toStartAtBeginningIterator0)
 	count1 := countItems(toStartAtBeginningIterator1)
@@ -1570,11 +1570,11 @@ func TestIterator(t *testing.T) {
 	aStore.StartAtBeginning(
 		kEndpoint0, "toStartAtBeginning0", "toStartAtBeginning1")
 
-	toStartAtBeginningIterator0, _ = aStore.NamedIteratorForEndpoint(
+	toStartAtBeginningIterator0, _, _ = aStore.NamedIteratorForEndpoint(
 		"toStartAtBeginning0", kEndpoint0, 0)
-	toStartAtBeginningIterator1, _ = aStore.NamedIteratorForEndpoint(
+	toStartAtBeginningIterator1, _, _ = aStore.NamedIteratorForEndpoint(
 		"toStartAtBeginning1", kEndpoint0, 0)
-	toStartAtBeginningIterator2, _ = aStore.NamedIteratorForEndpoint(
+	toStartAtBeginningIterator2, _, _ = aStore.NamedIteratorForEndpoint(
 		"toStartAtBeginning2", kEndpoint0, 0)
 	assertValueEquals(t, count0, countItems(toStartAtBeginningIterator0))
 	assertValueEquals(t, count1, countItems(toStartAtBeginningIterator1))
@@ -1583,28 +1583,28 @@ func TestIterator(t *testing.T) {
 	toStartAtBeginningIterator0.Commit()
 	toStartAtBeginningIterator1.Commit()
 
-	toStartAtBeginningIterator0, _ = aStore.NamedIteratorForEndpoint(
+	toStartAtBeginningIterator0, _, _ = aStore.NamedIteratorForEndpoint(
 		"toStartAtBeginning0", kEndpoint0, 0)
-	toStartAtBeginningIterator1, _ = aStore.NamedIteratorForEndpoint(
+	toStartAtBeginningIterator1, _, _ = aStore.NamedIteratorForEndpoint(
 		"toStartAtBeginning1", kEndpoint0, 0)
 
 	assertValueEquals(t, 0, countItems(toStartAtBeginningIterator0))
 	assertValueEquals(t, 0, countItems(toStartAtBeginningIterator1))
 
 	// Test SetIteratorTo
-	multipleCommitsIterator, _ := aStore.NamedIteratorForEndpoint(
+	multipleCommitsIterator, _, _ := aStore.NamedIteratorForEndpoint(
 		"multipleCommitsIterator", kEndpoint0, 0)
 	totalItems := countItems(multipleCommitsIterator)
 	if totalItems == 0 {
 		t.Error("Oops didn't get any records")
 	}
 
-	multipleCommitsIterator, _ = aStore.NamedIteratorForEndpoint(
+	multipleCommitsIterator, _, _ = aStore.NamedIteratorForEndpoint(
 		"multipleCommitsIterator", kEndpoint0, 0)
 	aStore.SetIteratorTo(kEndpoint0, "copy", "multipleCommitsIterator")
 	var r store.Record
 	for multipleCommitsIterator.Next(&r) {
-		copyIterator, _ := aStore.NamedIteratorForEndpoint(
+		copyIterator, _, _ := aStore.NamedIteratorForEndpoint(
 			"copy", kEndpoint0, 0)
 		assertValueEquals(t, totalItems, countItems(copyIterator))
 		totalItems--
@@ -1883,7 +1883,7 @@ func TestMachineGoneInactive(t *testing.T) {
 	expectedTsValues.Add("/foo/baz", 1920.0, int64(22))
 	expectedTsValues.AddInactive("/foo/baz", 1920.001, int64(0))
 
-	iterator, _ := aStore.NamedIteratorForEndpoint("aname", kEndpoint1, 0)
+	iterator, _, _ := aStore.NamedIteratorForEndpoint("aname", kEndpoint1, 0)
 
 	expectedTsValues.Iterate(t, iterator)
 	expectedTsValues.VerifyDone(t)
@@ -1974,7 +1974,7 @@ func TestSomeMissingSomePresentTimeStamps(t *testing.T) {
 		"/one/noTimeStamp2",
 		1300.0,
 		int64(102))
-	iterator, _ := aStore.NamedIteratorForEndpoint("aname", kEndpoint0, 0)
+	iterator, _, _ := aStore.NamedIteratorForEndpoint("aname", kEndpoint0, 0)
 	expectedTsValues.Iterate(t, iterator)
 	expectedTsValues.VerifyDone(t)
 }
@@ -2013,7 +2013,7 @@ func TestLMMDropOffEarlyTimestamps(t *testing.T) {
 
 	// Even though we request 2 values per metric, we get nothing
 	// because the first 2 timestamps don't match any value.
-	iterator, _ := aStore.NamedIteratorForEndpoint("aname", kEndpoint0, 2)
+	iterator, _, _ := aStore.NamedIteratorForEndpoint("aname", kEndpoint0, 2)
 	expectedTsValues.Iterate(t, iterator)
 	expectedTsValues.VerifyDone(t)
 
@@ -2023,7 +2023,7 @@ func TestLMMDropOffEarlyTimestamps(t *testing.T) {
 	expectedTsValues.Add("/foo/bar", 1600.0, int64(16))
 	expectedTsValues.Add("/foo/bar", 1700.0, int64(16))
 
-	iterator, _ = aStore.NamedIteratorForEndpoint("aname", kEndpoint0, 0)
+	iterator, _, _ = aStore.NamedIteratorForEndpoint("aname", kEndpoint0, 0)
 	expectedTsValues.Iterate(t, iterator)
 	expectedTsValues.VerifyDone(t)
 }
@@ -2706,7 +2706,7 @@ func TestWithDistributions(t *testing.T) {
 
 	// Test iterating. Iterators should include
 	// distribution values
-	iterator, _ := aStore.NamedIteratorForEndpoint(
+	iterator, _, _ := aStore.NamedIteratorForEndpoint(
 		"anIterator", kEndpoint0, 0)
 	expectedTsValues.Iterate(t, iterator)
 	expectedTsValues.VerifyDone(t)
@@ -2735,7 +2735,7 @@ func TestWithDistributions(t *testing.T) {
 		3000.0,
 		int64(74))
 
-	iterator, _ = aStore.NamedIteratorForEndpointRollUp(
+	iterator, _, _ = aStore.NamedIteratorForEndpointRollUp(
 		"anIterator",
 		kEndpoint0,
 		500*time.Second,
@@ -2849,7 +2849,7 @@ func TestWithLists(t *testing.T) {
 	expectedTsValues.Add(
 		"/list/string", 3000.0, []string{"hello", "goodbye"})
 
-	iterator, _ := aStore.NamedIteratorForEndpoint(
+	iterator, _, _ := aStore.NamedIteratorForEndpoint(
 		"anIterator", kEndpoint0, 0)
 	expectedTsValues.Iterate(t, iterator)
 	expectedTsValues.VerifyDone(t)
@@ -2867,7 +2867,7 @@ func TestWithLists(t *testing.T) {
 	expectedTsValues.Add(
 		"/list/string", 2800.0, []string{"foo", "bar", "baz"})
 
-	iterator, _ = aStore.NamedIteratorForEndpointRollUp(
+	iterator, _, _ = aStore.NamedIteratorForEndpointRollUp(
 		"aRollUpIterator",
 		kEndpoint0,
 		100*time.Second,


### PR DESCRIPTION
The writePositionIndex 0-100 estimates what data scotty is currently writing
to a particular data store. 100 means scotty is writing the most recent
data and is completely caught up; 0 means scotty is writing the earliest
data it has and is way behind. When the index is near 0, data is likely to be
evicted before written.