### PR TITLE
Fix url forming bug in cloudhealth module.

### DIFF
--- a/apps/scotty/collect.go
+++ b/apps/scotty/collect.go
@@ -308,7 +308,8 @@ func newCloudHealthWriter(reader io.Reader) (interface{}, error) {
 	if err := yamlutil.Read(reader, &config); err != nil {
 		return nil, err
 	}
-	return cloudhealth.NewWriter(config), nil
+	writer, err := cloudhealth.NewWriter(config)
+	return writer, err
 }
 
 func newCloudWatchWriter(reader io.Reader) (interface{}, error) {

--- a/cloudhealth/api.go
+++ b/cloudhealth/api.go
@@ -120,10 +120,11 @@ func (c *Config) Reset() {
 
 type Writer struct {
 	config Config
+	urlStr string
 }
 
 // NewWriter returns a new Writer instance.
-func NewWriter(config Config) *Writer {
+func NewWriter(config Config) (*Writer, error) {
 	return newWriter(config)
 }
 


### PR DESCRIPTION
Upgrading to go1.8 exposed a bug in my code. I was stuffing the entire
URL string in the Path field of net/url. While this wworked fine in earlier
versions of go, it doesn't work in go1.8. To fix, I use url.Parse() instead
of forming the url manually.

I also form the URL in the constructor rather than in the Write method
as forming the URL anew every time in the Write method slows down
writing.