### PR TITLE
Send tenantId and apikey as headers to lmm rest API.

### DIFF
--- a/cis/client.go
+++ b/cis/client.go
@@ -38,7 +38,7 @@ func (c *Client) write(stats *Stats) error {
 	}
 	url := fmt.Sprintf("%s/%s/%s/%s", c.endpoint, kCisPath, c.dataCenter, stats.InstanceId)
 	if c.sync != nil {
-		err := c.sync.Write(url, jsonToEncode)
+		err := c.sync.Write(url, nil, jsonToEncode)
 		if err != nil {
 			return fmt.Errorf("%s: %v", url, err)
 		}

--- a/lib/synchttp/api.go
+++ b/lib/synchttp/api.go
@@ -1,9 +1,15 @@
 package synchttp
 
+import (
+	"net/http"
+)
+
 // JSONWriter posts json to a rest API.
 type JSONWriter interface {
-	// url is the endpoint of the rest API. payload is marshalled into JSON.
-	Write(url string, payload interface{}) error
+	// url is the endpoint of the rest API. headers are any additional
+	// content headers to be written besides "Content-Type: application/json";
+	// payload is marshalled into JSON.
+	Write(url string, headers http.Header, payload interface{}) error
 }
 
 // NewSyncJSONWriter creates a synchronous json writer.

--- a/lib/synchttp/writer.go
+++ b/lib/synchttp/writer.go
@@ -19,13 +19,24 @@ func newSyncJSONWriter() (JSONWriter, error) {
 	return kSyncJSONWriter, nil
 }
 
-func (w *syncJSONWriterType) Write(url string, payload interface{}) error {
+func (w *syncJSONWriterType) Write(
+	url string, headers http.Header, payload interface{}) error {
 	buffer, err := encodeJSON(payload)
 	if err != nil {
 		return err
 	}
 	payloadStr := buffer.String()
-	response, err := w.client.Post(url, "application/json", buffer)
+	req, err := http.NewRequest("POST", url, buffer)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for name, values := range headers {
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+	response, err := w.client.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
LMM now requires these new content headers. 