### PR TITLE
Remove NaN and Inf from scotty metrics.

### DIFF
--- a/pstore/api.go
+++ b/pstore/api.go
@@ -112,7 +112,7 @@ type RecordWriterMetrics struct {
 
 func (w *RecordWriterMetrics) SuccessfulWriteRatio() float64 {
 	if w.WriteAttempts == 0 {
-		return 1.0
+		return 0.0
 	}
 	return float64(w.SuccessfulWrites) / float64(w.WriteAttempts)
 }

--- a/pstore/api.go
+++ b/pstore/api.go
@@ -111,6 +111,9 @@ type RecordWriterMetrics struct {
 }
 
 func (w *RecordWriterMetrics) SuccessfulWriteRatio() float64 {
+	if w.WriteAttempts == 0 {
+		return 1.0
+	}
 	return float64(w.SuccessfulWrites) / float64(w.WriteAttempts)
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -193,7 +193,7 @@ func (s *Store) registerMetrics(d *tricorder.DirectorySpec) (err error) {
 			metricCount := metrics.PagesPerMetricDist.Count()
 			extraValueCount := float64(metricValueCount) - float64(metricCount)
 			if pagesInUseCount == 0.0 {
-				return 1.0
+				return 0.0
 			}
 			return extraValueCount / pagesInUseCount / float64(maxValuesPerPage)
 		},

--- a/store/store.go
+++ b/store/store.go
@@ -192,6 +192,9 @@ func (s *Store) registerMetrics(d *tricorder.DirectorySpec) (err error) {
 			pagesInUseCount := metrics.PagesPerMetricDist.Sum()
 			metricCount := metrics.PagesPerMetricDist.Count()
 			extraValueCount := float64(metricValueCount) - float64(metricCount)
+			if pagesInUseCount == 0.0 {
+				return 1.0
+			}
 			return extraValueCount / pagesInUseCount / float64(maxValuesPerPage)
 		},
 		storeGroup,


### PR DESCRIPTION
NaN and Inf don't convert to JSON, so when they are present in metrics,
scotty cannot render those metrics as JSON.

The big question is how should we generally handle NaN and Inf in
metrics that scotty collects since those values can't be rendered as
JSON?