### PR TITLE
Show cloud health/ cloud watch status in showallapps page.

### DIFF
--- a/apps/scotty/scotty.go
+++ b/apps/scotty/scotty.go
@@ -444,8 +444,11 @@ func main() {
 	http.Handle(
 		"/showAllApps",
 		gzipHandler{&showallapps.Handler{
-			AS:             applicationStats,
-			CollectionFreq: *fCollectionFrequency,
+			AS:              applicationStats,
+			CollectionFreq:  *fCollectionFrequency,
+			CloudWatchTest:  *fCloudWatchTest,
+			CloudHealthTest: *fCloudHealthTest,
+			DefaultCwRate:   *fCloudWatchFreq,
 		}})
 	http.Handle(
 		"/api/hosts/",

--- a/datastructs/api.go
+++ b/datastructs/api.go
@@ -125,24 +125,18 @@ func (a *ApplicationStatus) InstanceId() string {
 	return a.instanceId()
 }
 
-// CloudHealthTest returns true iff the machine of this endpoint is for testing
-// scotty with cloud health
-func (a *ApplicationStatus) CloudHealthTest() bool {
-	return a.forTest("ScottyCloudHealthTest")
+func (a *ApplicationStatus) DoCloudHealth(testing bool) bool {
+	return testing == a.forTest("ScottyCloudHealthTest")
 }
 
-// CloudWatchTest returns true iff the machine of this endpoint is for testing
-// scotty with cloud watch
-func (a *ApplicationStatus) CloudWatchTest() bool {
-	return a.forTest("ScottyCloudWatchTest")
+func (a *ApplicationStatus) DoCloudWatch(
+	defaultRate time.Duration, testing bool) (time.Duration, bool) {
+	return a.doCloudWatch(defaultRate, testing)
 }
 
-// CloudWatch returns how often data for the machine gets written to
-// cloud watch as a string like "5m" If the rate is to be whatever the
-// default rate is, returns "defaultRate". If data not to be written to
-// cloudwatch, returns the empty string.
-func (a *ApplicationStatus) CloudWatch() string {
-	return a.cloudWatch()
+func (a *ApplicationStatus) DoCloudWatchStr(
+	defaultRate time.Duration, testing bool) string {
+	return a.doCloudWatchStr(defaultRate, testing)
 }
 
 // Returns last error time as 2006-01-02T15:04:05

--- a/datastructs/datastructs.go
+++ b/datastructs/datastructs.go
@@ -113,16 +113,21 @@ func (a *ApplicationStatus) forTest(tagName string) bool {
 	return false
 }
 
-func (a *ApplicationStatus) cloudWatch() string {
-	if a.Aws != nil {
-		if result, ok := a.Aws.Tags[kCloudWatchTag]; ok {
-			if _, err := parseDuration(result); err != nil {
-				return "defaultRate"
-			}
-			return result
-		}
+func (a *ApplicationStatus) doCloudWatchStr(
+	defaultRate time.Duration, testing bool) string {
+	dur, ok := a.doCloudWatch(defaultRate, testing)
+	if ok {
+		return dur.String()
 	}
 	return ""
+}
+
+func (a *ApplicationStatus) doCloudWatch(
+	defaultRate time.Duration, testing bool) (time.Duration, bool) {
+	if testing == a.forTest("ScottyCloudWatchTest") {
+		return a.cloudWatchRefreshRate(defaultRate)
+	}
+	return 0, false
 }
 
 func (a *ApplicationStatus) cloudWatchRefreshRate(defaultRate time.Duration) (

--- a/datastructs/endpointdata.go
+++ b/datastructs/endpointdata.go
@@ -16,7 +16,7 @@ func (e *EndpointData) updateForCloudHealth(
 	if app.Aws == nil {
 		return e
 	}
-	needToDoCloudHealth := bTestRun == app.CloudHealthTest()
+	needToDoCloudHealth := app.DoCloudHealth(bTestRun)
 	doingCloudHealth := e.CHRollup != nil
 	if needToDoCloudHealth != doingCloudHealth {
 		result := *e
@@ -46,8 +46,7 @@ func (e *EndpointData) updateForCloudWatch(
 	app *ApplicationStatus,
 	defaultFreq time.Duration,
 	bTestRun bool) *EndpointData {
-	rate, rateOk := app.CloudWatchRefreshRate(defaultFreq)
-	rateOk = rateOk && (bTestRun == app.CloudWatchTest())
+	rate, rateOk := app.DoCloudWatch(defaultFreq, bTestRun)
 	cwExists := e.CWRollup != nil
 
 	// Calling RoundDuration() here is safe because its returned value never


### PR DESCRIPTION
In this PR, for each machine, scotty shows whether or not it is writing
to cloudhealth and cloudwatch. CH means writing to cloudhealth; CW: 5m means
writing to cloud watch every 5 minutes.

I did some refactoring so that the code that decides whether to write to
cloudwatch or cloudhealth is in one place. Before there was some code
duplication because I had decided to display some cloudwatch information in
scotty as an afterthought.