### PR TITLE
Bug fix in opentsdb json parsing.

### DIFF
--- a/tsdbjson/tsdbjson.go
+++ b/tsdbjson/tsdbjson.go
@@ -221,7 +221,7 @@ func parseDownSample(downSampleStr string) (result *DownSampleSpec, err error) {
 func (p *ParsedQuery) ensureStartTimeRecentEnough() {
 	if p.Aggregator.DownSample != nil {
 		downSample := p.Aggregator.DownSample
-		if p.End-p.Start/downSample.DurationInSeconds > kMaxDownSampleBuckets {
+		if (p.End-p.Start)/downSample.DurationInSeconds > kMaxDownSampleBuckets {
 			p.Start = p.End - downSample.DurationInSeconds*kMaxDownSampleBuckets
 		}
 	}


### PR DESCRIPTION
Missing parens in math expression was causing start time of opentsdb
queries to be changed to the earliest possible start time for the
maximum number of time buckets allowed even when the original start time
was later.