### PR TITLE
Scotty to wait 1.5 to 4.5 hours between writing to CIS

### DIFF
--- a/apps/scotty/collect.go
+++ b/apps/scotty/collect.go
@@ -834,9 +834,16 @@ func startCisLoop(
 						lastSuccessfulWriteTime = time.Now()
 					}
 				}
-				totalWrites++
-				writeTimesDist.Add(time.Since(writeStartTime))
+				totalWrites += uint64(numWritten)
+				if numWritten > 0 {
+					timeElapsed := time.Since(writeStartTime)
+					timePerWrite := timeElapsed / time.Duration(numWritten)
+					for i := 0; i < numWritten; i++ {
+						writeTimesDist.Add(timePerWrite)
+					}
+				}
 			}
+			writeStartTime := time.Now()
 			numWritten, err := bulkCisClient.Flush()
 			if err != nil {
 				logger.Printf("Error writing to CIS: %v", err)
@@ -845,6 +852,14 @@ func startCisLoop(
 				successfulWrites += uint64(numWritten)
 				if numWritten > 0 {
 					lastSuccessfulWriteTime = time.Now()
+				}
+			}
+			totalWrites += uint64(numWritten)
+			if numWritten > 0 {
+				timeElapsed := time.Since(writeStartTime)
+				timePerWrite := timeElapsed / time.Duration(numWritten)
+				for i := 0; i < numWritten; i++ {
+					writeTimesDist.Add(timePerWrite)
 				}
 			}
 		}

--- a/cis/api.go
+++ b/cis/api.go
@@ -129,16 +129,18 @@ func NewBuffered(size int, writer BulkWriter) *Buffered {
 	}
 }
 
-// Write buffers data. When size pieces of data are buffered, Write bulk
+// Write buffers data. When size pieces of data are buffered, Write
 // clears the buffer, and reports number of pieces written and any error.
 // When simply adding to the buffer instead of bulk writing, Write always
-// returns 0, nil.
+// returns 0, nil. Even on error, Write returns the number of pieces that
+// would have been written if there was no error.
 func (b *Buffered) Write(stats Stats) (int, error) {
 	return b.write(stats)
 }
 
 // Flush writes out the contents of the buffer, clears the buffer, and
-// returns number of pieces written and any error.
+// returns number of pieces written and any error. On error, Flush returns
+// the number of pieces that would have been written.
 func (b *Buffered) Flush() (int, error) {
 	return b.flush()
 }

--- a/cis/buffered.go
+++ b/cis/buffered.go
@@ -24,7 +24,7 @@ func (b *Buffered) _flush() (int, error) {
 	result := b.writer.WriteAll(b.statsList)
 	b.statsList = b.statsList[:0]
 	if result != nil {
-		return 0, result
+		return l, result
 	}
 	return l, nil
 }

--- a/lib/keyedqueue/api.go
+++ b/lib/keyedqueue/api.go
@@ -50,3 +50,9 @@ func (q *Queue) Add(elementToAdd Element) {
 func (q *Queue) Remove() Element {
 	return q.remove()
 }
+
+// Peek returns the element at the front of the queue without removing it.
+// If queue is empty, Peek blocks.
+func (q *Queue) Peek() Element {
+	return q.peek()
+}

--- a/lib/keyedqueue/keyedqueue.go
+++ b/lib/keyedqueue/keyedqueue.go
@@ -30,3 +30,12 @@ func (q *Queue) remove() Element {
 	delete(q.byKey, removedElement.Key())
 	return removedElement
 }
+
+func (q *Queue) peek() Element {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	for q.queue.Len() == 0 {
+		q.elementsOn.Wait()
+	}
+	return q.queue.Front().Value.(Element)
+}

--- a/lib/keyedqueue/keyedqueue_test.go
+++ b/lib/keyedqueue/keyedqueue_test.go
@@ -46,9 +46,11 @@ func TestQueue(t *testing.T) {
 
 			Convey("A,B,C,D removed", func() {
 				So(queue.Len(), ShouldEqual, 4)
+				So(queue.Peek().(*element).K, ShouldEqual, "A")
 				So(queue.Remove().(*element).K, ShouldEqual, "A")
 				So(queue.Remove().(*element).K, ShouldEqual, "B")
 				So(queue.Remove().(*element).K, ShouldEqual, "C")
+				So(queue.Peek().(*element).K, ShouldEqual, "D")
 				So(queue.Remove().(*element).K, ShouldEqual, "D")
 				So(queue.Len(), ShouldEqual, 0)
 			})


### PR DESCRIPTION
- The first commit. Makes scotty wait 1.5 to 4.5 hours between writes of all the package data it has to CIS.  The basic idea is in a loop:  1. Sleep some random amount of time between 1.5 and 4.5 hours 2. Write all the data in the queue to CIS.
- The second commit changes how we collect metrics on CIS writes times. Since we buffer writes and send all the writes to CIS in a batch, we showed most of the rights taking no time at all while the small percentage that happened when the buffer flushed took inordinate amounts of time. Now we only log CIS write times when the buffer flushes averaging the the time taken to write the batch across each instance.