### PR TITLE
Add sliding counters to persistent store writers

### DIFF
--- a/apps/scotty/pstorehandler.go
+++ b/apps/scotty/pstorehandler.go
@@ -322,7 +322,8 @@ func (p *pstoreHandlerType) RegisterMetrics() (err error) {
 		return
 	}
 	if err = p.writeCount.Register(
-		fmt.Sprintf("writer/%s/writeCount", p.Name())); err != nil {
+		fmt.Sprintf("writer/%s/writeCount", p.Name()),
+		"write count"); err != nil {
 		return
 	}
 	if err = tricorder.RegisterMetric(

--- a/apps/scotty/pstorehandler.go
+++ b/apps/scotty/pstorehandler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Symantec/Dominator/lib/log"
 	"github.com/Symantec/Dominator/lib/log/prefixlogger"
 	"github.com/Symantec/scotty/lib/gate"
+	"github.com/Symantec/scotty/lib/trimetrics"
 	"github.com/Symantec/scotty/machine"
 	"github.com/Symantec/scotty/pstore"
 	"github.com/Symantec/scotty/pstore/config"
@@ -153,6 +154,7 @@ type pstoreHandlerType struct {
 	percentCaughtUp     store.FloatVar
 	totalTimeSpentDist  *tricorder.CumulativeDistribution
 	perMetricWriteTimes *tricorder.CumulativeDistribution
+	writeCount          *trimetrics.SlidingSuccessCounter
 	visitorMetricsStore *visitorMetricsStoreType
 	maybeNilCoord       store.Coordinator
 }
@@ -168,19 +170,22 @@ type coordinatorBuilderType interface {
 	WatchPStoreConfig(done <-chan struct{}) <-chan string
 }
 
-// appList converts port numbers to application names.
 // consumer is what builds the consumer to write to the pstore
 // perMetricWriteTimes is the distribution to where write speeds get
-// recorded. totalTimeSpentDist is the distribution to where total time spent
+// recorded.
+// writeCount keeps track of write successes and failures over periods of time.
+// totalTimeSpentDist is the distribution to where total time spent
 // doing one cycle of writing out the scotty store gets recorded. If
 // maybeNilCoordBuilder is not nil, it arranges to acquire a lease from
 // consul before any writing happens.
 func newPStoreHandler(
 	consumer *pstore.ConsumerWithMetricsBuilder,
 	perMetricWriteTimes *tricorder.CumulativeDistribution,
+	writeCount *trimetrics.SlidingSuccessCounter,
 	totalTimeSpentDist *tricorder.CumulativeDistribution,
 	maybeNilCoordBuilder coordinatorBuilderType) *pstoreHandlerType {
 	consumer.SetPerMetricWriteTimeDist(perMetricWriteTimes)
+	consumer.SetWriteCount(writeCount)
 	visitorMetricsStore := newVisitorMetricsStoreType()
 	var maybeNilCoord store.Coordinator
 	if maybeNilCoordBuilder != nil {
@@ -191,6 +196,7 @@ func newPStoreHandler(
 		consumer:            consumer.Build(),
 		totalTimeSpentDist:  totalTimeSpentDist,
 		perMetricWriteTimes: perMetricWriteTimes,
+		writeCount:          writeCount,
 		visitorMetricsStore: visitorMetricsStore,
 		maybeNilCoord:       maybeNilCoord,
 	}
@@ -313,6 +319,10 @@ func (p *pstoreHandlerType) RegisterMetrics() (err error) {
 		p.perMetricWriteTimes,
 		units.Millisecond,
 		"Time spent writing each metric"); err != nil {
+		return
+	}
+	if err = p.writeCount.Register(
+		fmt.Sprintf("writer/%s/writeCount", p.Name())); err != nil {
 		return
 	}
 	if err = tricorder.RegisterMetric(
@@ -512,18 +522,22 @@ func newPStoreRunner(
 	logger log.Logger) *pstoreRunnerType {
 	var perMetricWriteTimes *tricorder.CumulativeDistribution
 	var totalTimeSpentDist *tricorder.CumulativeDistribution
+	var writeCount *trimetrics.SlidingSuccessCounter
 	if maybeNilInAttrs != nil {
 		perMetricWriteTimes = maybeNilInAttrs.PerMetricWriteTimes
+		writeCount = maybeNilInAttrs.WriteCount
 		totalTimeSpentDist = maybeNilInAttrs.TotalTimeSpentDist
 		consumer.SetConsumerMetrics(&maybeNilInAttrs.ConsumerMetrics)
 	} else {
 		perMetricWriteTimes = kBucketer.NewCumulativeDistribution()
 		totalTimeSpentDist = kBucketer.NewCumulativeDistribution()
+		writeCount = trimetrics.NewSlidingSuccessCounter()
 	}
 	consumer.SetLogger(prefixlogger.New(consumer.Name()+": ", logger))
 	handler := newPStoreHandler(
 		consumer,
 		perMetricWriteTimes,
+		writeCount,
 		totalTimeSpentDist,
 		maybeNilCoordBuilder)
 	var attributes pstore.ConsumerAttributes

--- a/lib/trimetrics/api.go
+++ b/lib/trimetrics/api.go
@@ -4,9 +4,33 @@ package trimetrics
 
 import (
 	"github.com/Symantec/tricorder/go/tricorder"
+	"github.com/Symantec/tricorder/go/tricorder/units"
 	"sync"
 	"time"
 )
+
+type SlidingSuccessCounter struct {
+	now time.Time
+}
+
+func NewSlidingSuccessCounter() *SlidingSuccessCounter {
+	return &SlidingSuccessCounter{now: time.Now()}
+}
+
+func (s *SlidingSuccessCounter) Add(total, success uint64) {
+}
+
+func (s *SlidingSuccessCounter) Elapsed() int64 {
+	return int64(time.Since(s.now) / time.Second)
+}
+
+func (s *SlidingSuccessCounter) Register(path string) error {
+	return tricorder.RegisterMetric(
+		path,
+		s.Elapsed,
+		units.Second,
+		"time elapsed in seconds")
+}
 
 // Duration stores a time.Duration behind a mutex
 type Duration struct {

--- a/lib/trimetrics/api.go
+++ b/lib/trimetrics/api.go
@@ -43,7 +43,8 @@ func (s *SlidingSuccessCounter) Inc(total, success int64) {
 // 	_total_1d - total over last 24 hours
 // 	_total_1h - total over last 1 hour
 func (s *SlidingSuccessCounter) Register(path, desc string) error {
-	return s.register(path, desc)
+	root, _ := tricorder.RegisterDirectory("/")
+	return s.registerUnder(root, path, desc)
 }
 
 // Duration stores a time.Duration behind a mutex
@@ -88,6 +89,7 @@ func (c *Counter) Inc(x uint64) {
 type WriterMetrics struct {
 	timeToWriteDist *tricorder.CumulativeDistribution
 	batchSizeDist   *tricorder.CumulativeDistribution
+	counter         *SlidingSuccessCounter
 	mu              sync.Mutex
 	singles         writerSingleMetricsType
 }

--- a/lib/trimetrics/ringcounter.go
+++ b/lib/trimetrics/ringcounter.go
@@ -1,0 +1,54 @@
+package trimetrics
+
+type ringCounterType struct {
+	size            int
+	counts          []int64
+	total           int64
+	currentInterval uint64
+}
+
+func (r *ringCounterType) Init(size int) {
+	if size <= 0 {
+		panic("size must be > 0")
+	}
+	r.size = size
+	r.counts = make([]int64, size)
+}
+
+func (r *ringCounterType) Inc(interval uint64, count int64) {
+	if r.advanceTo(interval) {
+		r.counts[r.index()] += count
+		r.total += count
+	}
+}
+
+func (r *ringCounterType) Total(interval uint64) int64 {
+	r.advanceTo(interval)
+	return r.total
+}
+
+func (r *ringCounterType) index() int {
+	return int(r.currentInterval % uint64(r.size))
+}
+
+func (r *ringCounterType) advanceTo(interval uint64) bool {
+	if interval < r.currentInterval {
+		return false
+	}
+	// No need to advance more then r.size as doing so zeros out the
+	// total and the counts
+	advanceCount := 0
+	for r.currentInterval < interval && advanceCount < r.size {
+		r.advanceOne()
+		advanceCount++
+	}
+	r.currentInterval = interval
+	return true
+}
+
+func (r *ringCounterType) advanceOne() {
+	r.currentInterval++
+	idx := r.index()
+	r.total -= r.counts[idx]
+	r.counts[idx] = 0
+}

--- a/lib/trimetrics/ringcounter_test.go
+++ b/lib/trimetrics/ringcounter_test.go
@@ -1,0 +1,37 @@
+package trimetrics
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestAPI(t *testing.T) {
+	Convey("API", t, func() {
+		var total ringCounterType
+		total.Init(5)
+		total.Inc(3, 6)
+		total.Inc(4, 2)
+		total.Inc(4, 5)
+		So(total.Total(4), ShouldEqual, 13)
+		// Going back in time has no affect
+		total.Inc(2, 102)
+		So(total.Total(2), ShouldEqual, 13)
+		// Starting at present time again has affect
+		total.Inc(4, 1)
+		So(total.Total(4), ShouldEqual, 14)
+		total.Inc(5, 10)
+		total.Inc(7, 4)
+		So(total.Total(7), ShouldEqual, 28)
+		// ring counter now full
+		// Advancing to 9 evicts 3=6 and 4=8
+		So(total.Total(9), ShouldEqual, 14)
+		total.Inc(10, 3)
+		// 7=4, 10=3 total 7
+		So(total.Total(10), ShouldEqual, 7)
+		// Test advancing more than 5
+		total.Inc(17, 5)
+		total.Inc(17, 3)
+		So(total.Total(17), ShouldEqual, 8)
+	})
+}

--- a/lib/trimetrics/slidingsuccesscounter.go
+++ b/lib/trimetrics/slidingsuccesscounter.go
@@ -1,0 +1,96 @@
+package trimetrics
+
+import (
+	"github.com/Symantec/tricorder/go/tricorder"
+	"github.com/Symantec/tricorder/go/tricorder/units"
+	"time"
+)
+
+type slidingSuccessCounterDataType struct {
+	TotalHour   int64
+	TotalDay    int64
+	SuccessHour int64
+	SuccessDay  int64
+}
+
+func (s *slidingSuccessCounterDataType) SuccessRatioHour() float64 {
+	if s.TotalHour == 0 {
+		return 1.0
+	}
+	return float64(s.SuccessHour) / float64(s.TotalHour)
+}
+
+func (s *slidingSuccessCounterDataType) SuccessRatioDay() float64 {
+	if s.TotalDay == 0 {
+		return 1.0
+	}
+	return float64(s.SuccessDay) / float64(s.TotalDay)
+}
+
+func newSlidingSuccessCounter() *SlidingSuccessCounter {
+	result := &SlidingSuccessCounter{}
+	result.totalHour.Init(60)
+	result.successHour.Init(60)
+	result.totalDay.Init(60 * 24)
+	result.successDay.Init(60 * 24)
+	return result
+}
+
+func getSlot() uint64 {
+	minutes := time.Now().Unix() / 60
+	if minutes < 0 {
+		minutes = 0
+	}
+	return uint64(minutes)
+}
+
+func (s *SlidingSuccessCounter) inc(total, success int64) {
+	slot := getSlot()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.totalHour.Inc(slot, total)
+	s.totalDay.Inc(slot, total)
+	s.successHour.Inc(slot, success)
+	s.successDay.Inc(slot, success)
+}
+
+func (s *SlidingSuccessCounter) get(result *slidingSuccessCounterDataType) {
+	slot := getSlot()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result.TotalHour = s.totalHour.Total(slot)
+	result.TotalDay = s.totalDay.Total(slot)
+	result.SuccessHour = s.successHour.Total(slot)
+	result.SuccessDay = s.successDay.Total(slot)
+}
+
+func (s *SlidingSuccessCounter) register(path, desc string) error {
+	var data slidingSuccessCounterDataType
+	grp := tricorder.NewGroup()
+	grp.RegisterUpdateFunc(func() time.Time {
+		s.get(&data)
+		return time.Now()
+	})
+	if err := grp.RegisterMetric(
+		path+"_total_1h", &data.TotalHour, units.None, desc); err != nil {
+		return err
+	}
+	if err := grp.RegisterMetric(
+		path+"_total_1d", &data.TotalDay, units.None, desc); err != nil {
+		return err
+	}
+	if err := grp.RegisterMetric(
+		path+"_success_1h", &data.SuccessHour, units.None, desc); err != nil {
+		return err
+	}
+	if err := grp.RegisterMetric(
+		path+"_success_1d", &data.SuccessDay, units.None, desc); err != nil {
+		return err
+	}
+	if err := grp.RegisterMetric(
+		path+"_ratio_1h", data.SuccessRatioHour, units.None, desc); err != nil {
+		return err
+	}
+	return grp.RegisterMetric(
+		path+"_ratio_1d", data.SuccessRatioDay, units.None, desc)
+}

--- a/lib/trimetrics/slidingsuccesscounter.go
+++ b/lib/trimetrics/slidingsuccesscounter.go
@@ -64,33 +64,35 @@ func (s *SlidingSuccessCounter) get(result *slidingSuccessCounterDataType) {
 	result.SuccessDay = s.successDay.Total(slot)
 }
 
-func (s *SlidingSuccessCounter) register(path, desc string) error {
+func (s *SlidingSuccessCounter) registerUnder(
+	dir *tricorder.DirectorySpec, path, desc string) error {
 	var data slidingSuccessCounterDataType
 	grp := tricorder.NewGroup()
 	grp.RegisterUpdateFunc(func() time.Time {
 		s.get(&data)
 		return time.Now()
 	})
-	if err := grp.RegisterMetric(
+	dg := tricorder.DirectoryGroup{Group: grp, Directory: dir}
+	if err := dg.RegisterMetric(
 		path+"_total_1h", &data.TotalHour, units.None, desc); err != nil {
 		return err
 	}
-	if err := grp.RegisterMetric(
+	if err := dg.RegisterMetric(
 		path+"_total_1d", &data.TotalDay, units.None, desc); err != nil {
 		return err
 	}
-	if err := grp.RegisterMetric(
+	if err := dg.RegisterMetric(
 		path+"_success_1h", &data.SuccessHour, units.None, desc); err != nil {
 		return err
 	}
-	if err := grp.RegisterMetric(
+	if err := dg.RegisterMetric(
 		path+"_success_1d", &data.SuccessDay, units.None, desc); err != nil {
 		return err
 	}
-	if err := grp.RegisterMetric(
+	if err := dg.RegisterMetric(
 		path+"_ratio_1h", data.SuccessRatioHour, units.None, desc); err != nil {
 		return err
 	}
-	return grp.RegisterMetric(
+	return dg.RegisterMetric(
 		path+"_ratio_1d", data.SuccessRatioDay, units.None, desc)
 }

--- a/pstore/api.go
+++ b/pstore/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Symantec/Dominator/lib/log"
 	"github.com/Symantec/Dominator/lib/log/nulllogger"
 	"github.com/Symantec/scotty/lib/gate"
+	"github.com/Symantec/scotty/lib/trimetrics"
 	"github.com/Symantec/scotty/store"
 	"github.com/Symantec/tricorder/go/tricorder"
 	"github.com/Symantec/tricorder/go/tricorder/types"
@@ -129,6 +130,7 @@ type RecordWriterWithMetrics struct {
 	PerMetricWriteTimes *tricorder.CumulativeDistribution
 	// Client populates this to collect batch sizes
 	BatchSizes      *tricorder.CumulativeDistribution
+	WriteCount      *trimetrics.SlidingSuccessCounter
 	Logger          log.Logger
 	criticalSection *gate.Gate
 	lock            sync.Mutex
@@ -380,6 +382,7 @@ type ConsumerAttributes struct {
 	MetricsToExclude    []*regexp.Regexp
 	BatchSizes          *tricorder.CumulativeDistribution
 	PerMetricWriteTimes *tricorder.CumulativeDistribution
+	WriteCount          *trimetrics.SlidingSuccessCounter
 }
 
 // WritesSameAs returns true if these consumer attributes would cause the
@@ -569,6 +572,11 @@ func (b *ConsumerWithMetricsBuilder) SetPerMetricWriteTimeDist(
 func (b *ConsumerWithMetricsBuilder) SetBatchSizeDist(
 	d *tricorder.CumulativeDistribution) {
 	b.c.attributes.BatchSizes = d
+}
+
+func (b *ConsumerWithMetricsBuilder) SetWriteCount(
+	counter *trimetrics.SlidingSuccessCounter) {
+	b.c.attributes.WriteCount = counter
 }
 
 // Attributes gets the attributes in this builder object

--- a/pstore/pstore.go
+++ b/pstore/pstore.go
@@ -80,7 +80,7 @@ func (w *RecordWriterWithMetrics) logWrite(
 	batchSize uint, timeTaken time.Duration) {
 	w.logDistributions(batchSize, timeTaken)
 	if w.WriteCount != nil {
-		w.WriteCount.Add(1, 1)
+		w.WriteCount.Inc(1, 1)
 	}
 	w.lock.Lock()
 	defer w.lock.Unlock()
@@ -91,7 +91,7 @@ func (w *RecordWriterWithMetrics) logWriteError(
 	batchSize uint, err error, timeTaken time.Duration) {
 	w.logDistributions(batchSize, timeTaken)
 	if w.WriteCount != nil {
-		w.WriteCount.Add(1, 0)
+		w.WriteCount.Inc(1, 0)
 	}
 	w.Logger.Printf("Error writing to persistent store: %v", err)
 	w.lock.Lock()

--- a/pstore/pstore.go
+++ b/pstore/pstore.go
@@ -79,6 +79,9 @@ func (w *RecordWriterWithMetrics) _metrics(m *RecordWriterMetrics) {
 func (w *RecordWriterWithMetrics) logWrite(
 	batchSize uint, timeTaken time.Duration) {
 	w.logDistributions(batchSize, timeTaken)
+	if w.WriteCount != nil {
+		w.WriteCount.Add(1, 1)
+	}
 	w.lock.Lock()
 	defer w.lock.Unlock()
 	w.metrics.logWrite(batchSize, timeTaken)
@@ -87,6 +90,9 @@ func (w *RecordWriterWithMetrics) logWrite(
 func (w *RecordWriterWithMetrics) logWriteError(
 	batchSize uint, err error, timeTaken time.Duration) {
 	w.logDistributions(batchSize, timeTaken)
+	if w.WriteCount != nil {
+		w.WriteCount.Add(1, 0)
+	}
 	w.Logger.Printf("Error writing to persistent store: %v", err)
 	w.lock.Lock()
 	defer w.lock.Unlock()
@@ -420,6 +426,7 @@ func (b *ConsumerWithMetricsBuilder) build() *ConsumerWithMetrics {
 	// fix up metrics
 	result.metricsStore.w.BatchSizes = result.attributes.BatchSizes
 	result.metricsStore.w.PerMetricWriteTimes = result.attributes.PerMetricWriteTimes
+	result.metricsStore.w.WriteCount = result.attributes.WriteCount
 	result.metricsStore.w.Logger = b.logger
 
 	result.metricsStore.SetMetrics(&b.metrics)


### PR DESCRIPTION
Add the following metrics to LMM:

/writer/lmm/writeCount_ratio_1d - successful writes / total writes over last 24 hours
/writer/lmm/writeCount_ratio_1h - successful writes / total writes over last hour
/writer/lmm/writeCount_success_1d - successful writes over last 24 hours
/writer/lmm/writeCount_success_1h - successful writes over last hour
/writer/lmm/writeCount_total_1d - total writes over last 24 hours
/writer/lmm/writeCount_total_1h - total writes over last hour
